### PR TITLE
copyright date change dynamically

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -69,7 +69,7 @@ export default function Footer() {
       </div>
       
       {/* Bottom Text */}
-      <p className="text-center text-sm text-gray-400 mt-10">&copy; 2024 DSA Practice. All Rights Reserved.</p>
+      <p className="text-center text-sm text-gray-400 mt-10">&copy; {new Date().getFullYear()} DSA Practice. All Rights Reserved.</p>
     </footer>
   );
 }


### PR DESCRIPTION
OPEN NEW PULL REQUEST AS EARLIER HAD MERGE CONFLICT
Fix: Implement Dynamic Copyright Year in Footer

This commit updates the copyright section in the footer to display the current year dynamically.
It uses `new Date().getFullYear()` to ensure the year automatically updates, preventing the copyright information from becoming outdated.

Other features discussed (like adding a 'Last Updated' date) are deferred for a future contribution. This is my first time going through the open-source contribution workflow (forking, branching, pushing to my fork, etc.), and I wanted to focus on getting this specific fix correctly implemented and reviewed first.