### PR TITLE
fix: remove duplicate footer on Progress page

### DIFF
--- a/Frontend/app/progress/page.tsx
+++ b/Frontend/app/progress/page.tsx
@@ -231,7 +231,6 @@ export default function ProgressPage() {
         </motion.div>
 
       </main>
-      <Footer />
     </>
   );
 }


### PR DESCRIPTION
### Summary
- Removed an extra `<Footer />` component on the Progress page
- Footer is now rendered only once via the global layout, ensuring consistent UI

Closes #48