### PR TITLE
Allow Sending Messages with Enter Key in BotWidget

### DIFF
--- a/components/BotWidget.tsx
+++ b/components/BotWidget.tsx
@@ -79,6 +79,11 @@ export default function BotWidget() {
               onChange={(e) => setInput(e.target.value)}
               placeholder="What have you covered so far?"
               className="flex-grow border p-2 rounded text-black"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  handleSend();
+                }
+              }}
             />
             <button
               onClick={handleSend}


### PR DESCRIPTION

**Description**
This PR improves the BotWidget chat experience by allowing users to send messages by pressing the Enter key in the input field, in addition to clicking the send button.

Fixed #98 

**Changes:**

-Added [onKeyDown] handler to the <Input /> component.
-Now, pressing Enter calls [handleSend()]and sends the message.

**How to Test**

- Open the BotWidget chat in the app.
- Type a message in the input box.
- Press Enter — the message should be sent.
- Alternatively, click the send button — the message should also be sent.


**Additional Notes**
No breaking changes.
No sensitive information (like API keys) included.
Please ensure your local .env.local is set up for API access.