### PR TITLE
Send Daily POTD notifications to registered emails.

### DIFF
--- a/.github/workflows/send-potd.yml
+++ b/.github/workflows/send-potd.yml
@@ -1,0 +1,13 @@
+name: Send POTD Daily
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # Runs daily at 9:30 AM IST (4:00 UTC)
+  workflow_dispatch:
+
+jobs:
+  send-potd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call deployed endpoint
+        run: curl -X GET "https://dsa-sheet-template.vercel.app/api/send-potd"

--- a/app/api/email-preference/route.ts
+++ b/app/api/email-preference/route.ts
@@ -1,0 +1,40 @@
+import { connect } from "@/db/config";
+import { User } from "@/models/User.model";
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  try {
+    await connect();
+
+    const { searchParams } = new URL(req.url);
+    const email = searchParams.get("email");
+    const action = searchParams.get("action");
+
+    if (!email || !action) {
+      return NextResponse.json({ success: false, message: "Missing email or action." }, { status: 400 });
+    }
+
+    const updates: Partial<{ subscribedToEmails: boolean; subscribedToNewsletter: boolean }> = {};
+
+    if (action === "unsubscribe") updates.subscribedToEmails = false;
+    else if (action === "newsletter") updates.subscribedToNewsletter = true;
+    else {
+      return NextResponse.json({ success: false, message: "Invalid action." }, { status: 400 });
+    }
+
+    const user = await User.findOneAndUpdate({ email }, updates, { new: true });
+
+    if (!user) {
+      return NextResponse.json({ success: false, message: "User not found." }, { status: 404 });
+    }
+    if (action === "unsubscribe") {
+        return NextResponse.json({ success: true, message: "You have been unsubscribed from emails." });
+    } else if (action === "newsletter") {
+        return NextResponse.json({ success: true, message: "You have been subscribed to the newsletter." });
+    }   
+    // return NextResponse.json({ success: true, message: `Successfully updated preferences for ${email}.` });
+  } catch (err) {
+    console.error("Error in /api/email-preference:", err);
+    return NextResponse.json({ success: false, message: "Server error." }, { status: 500 });
+  }
+}

--- a/app/api/send-potd/route.ts
+++ b/app/api/send-potd/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { connect } from "@/db/config";
+import { User } from "@/models/User.model";
+import { sendEmail } from "@/lib/mail";
+import { getPOTD } from "@/utils/getPOTD";
+
+export async function GET() {
+  try {
+    await connect(); // Connect to MongoDB
+
+    const users = await User.find({ subscribedToEmails: true }); // ✅ Define here only
+    const problem = getPOTD();
+
+    for (const user of users) {
+      if (!user.email) continue;
+
+      const platformLinks = Object.entries(problem.links || {})
+        .map(
+          ([platform, url]) =>
+            `<a href="${url}" target="_blank" style="color: #3b82f6;">${platform}</a>`
+        )
+        .join(" | ") || "No links available";
+        const baseUrl =
+            process.env.NODE_ENV === "production"
+                ? "https://dsa-sheet-template.vercel.app"
+                : "http://localhost:3000";
+
+      const html = `
+        <h2>🧠 DSAMate Problem of the Day</h2>
+        <p><strong>${problem.title}</strong></p>
+        <p>Difficulty: <strong>${problem.difficulty}</strong></p>
+        <p>Links: ${platformLinks}</p>
+        ${
+          problem.solutionLink
+            ? `<p><a href="${problem.solutionLink}" target="_blank">🔗 GitHub Solution</a></p>`
+            : ""
+        }
+        <br/>
+        <small>
+          <a href="${baseUrl}/email-preference?email=${user.email}&action=unsubscribe">Unsubscribe</a> |
+
+          <a href="${baseUrl}/email-preference?email=${user.email}&action=newsletter">Subscribe to Newsletter</a>
+        </small>
+      `;
+
+      await sendEmail({
+        to: user.email,
+        subject: `🧠 DSAMate POTD – ${problem.title}`,
+        html,
+      });
+    }
+
+    return NextResponse.json({ message: "POTD emails sent successfully!" });
+  } catch (error) {
+    console.error("❌ Error sending POTD emails:", error);
+    return NextResponse.json({ error: "Failed to send emails" }, { status: 500 });
+  }
+}

--- a/app/email-preference/content.tsx
+++ b/app/email-preference/content.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export default function EmailPreferencePage() {
+  const searchParams = useSearchParams();
+  const [message, setMessage] = useState("Processing your request...");
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+
+  useEffect(() => {
+    const action = searchParams.get("action");
+    const email = searchParams.get("email");
+
+    if (!email || !action) {
+      setMessage("Missing email or action.");
+      setStatus("error");
+      return;
+    }
+
+    const updatePreferences = async () => {
+      try {
+        const res = await fetch(`/api/email-preference?action=${action}&email=${email}`);
+        const data = await res.json();
+          if (res.ok && data.success) {
+              if (action === "unsubscribe") {
+                  setMessage("You have been unsubscribed.");
+              } else if (action === "newsletter") {
+                  setMessage("You have been subscribed to the newsletter.");
+              } else {
+                  setMessage(data.message);
+              }
+              setStatus("success");
+          } else {
+          setMessage(data.message || "Something went wrong.");
+          setStatus("error");
+        }
+      } catch (err) {
+        setMessage("Failed to update preferences.");
+        setStatus("error");
+      }
+    };
+
+    updatePreferences();
+  }, [searchParams]);
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-100">
+      <div className="bg-white shadow-md p-6 rounded-lg text-center max-w-md">
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">Email Preferences</h2>
+        <p className={`text-${status === "success" ? "green" : status === "error" ? "red" : "gray"}-600`}>
+          {message}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/email-preference/page.tsx
+++ b/app/email-preference/page.tsx
@@ -1,57 +1,10 @@
-"use client";
-
-import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { Suspense } from "react";
+import EmailPreferenceContent from "./content";
 
 export default function EmailPreferencePage() {
-  const searchParams = useSearchParams();
-  const [message, setMessage] = useState("Processing your request...");
-  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
-
-  useEffect(() => {
-    const action = searchParams.get("action");
-    const email = searchParams.get("email");
-
-    if (!email || !action) {
-      setMessage("Missing email or action.");
-      setStatus("error");
-      return;
-    }
-
-    const updatePreferences = async () => {
-      try {
-        const res = await fetch(`/api/email-preference?action=${action}&email=${email}`);
-        const data = await res.json();
-          if (res.ok && data.success) {
-              if (action === "unsubscribe") {
-                  setMessage("You have been unsubscribed.");
-              } else if (action === "newsletter") {
-                  setMessage("You have been subscribed to the newsletter.");
-              } else {
-                  setMessage(data.message);
-              }
-              setStatus("success");
-          } else {
-          setMessage(data.message || "Something went wrong.");
-          setStatus("error");
-        }
-      } catch (err) {
-        setMessage("Failed to update preferences.");
-        setStatus("error");
-      }
-    };
-
-    updatePreferences();
-  }, [searchParams]);
-
   return (
-    <div className="flex items-center justify-center h-screen bg-gray-100">
-      <div className="bg-white shadow-md p-6 rounded-lg text-center max-w-md">
-        <h2 className="text-xl font-semibold text-gray-900 mb-2">Email Preferences</h2>
-        <p className={`text-${status === "success" ? "green" : status === "error" ? "red" : "gray"}-600`}>
-          {message}
-        </p>
-      </div>
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <EmailPreferenceContent />
+    </Suspense>
   );
 }

--- a/app/email-preference/page.tsx
+++ b/app/email-preference/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export default function EmailPreferencePage() {
+  const searchParams = useSearchParams();
+  const [message, setMessage] = useState("Processing your request...");
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+
+  useEffect(() => {
+    const action = searchParams.get("action");
+    const email = searchParams.get("email");
+
+    if (!email || !action) {
+      setMessage("Missing email or action.");
+      setStatus("error");
+      return;
+    }
+
+    const updatePreferences = async () => {
+      try {
+        const res = await fetch(`/api/email-preference?action=${action}&email=${email}`);
+        const data = await res.json();
+          if (res.ok && data.success) {
+              if (action === "unsubscribe") {
+                  setMessage("You have been unsubscribed.");
+              } else if (action === "newsletter") {
+                  setMessage("You have been subscribed to the newsletter.");
+              } else {
+                  setMessage(data.message);
+              }
+              setStatus("success");
+          } else {
+          setMessage(data.message || "Something went wrong.");
+          setStatus("error");
+        }
+      } catch (err) {
+        setMessage("Failed to update preferences.");
+        setStatus("error");
+      }
+    };
+
+    updatePreferences();
+  }, [searchParams]);
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-100">
+      <div className="bg-white shadow-md p-6 rounded-lg text-center max-w-md">
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">Email Preferences</h2>
+        <p className={`text-${status === "success" ? "green" : status === "error" ? "red" : "gray"}-600`}>
+          {message}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/models/User.model.ts
+++ b/models/User.model.ts
@@ -11,6 +11,8 @@ export interface IUser extends Document {
   otpExpiry?: Date;
   resetToken?: string;
   resetTokenExpiry?: Date;
+  subscribedToEmails?: boolean;
+  subscribedToNewsletter?: boolean;
 }
 
 const UserSchema = new Schema<IUser>({
@@ -24,6 +26,9 @@ const UserSchema = new Schema<IUser>({
   otpExpiry: Date,
   resetToken: String,
   resetTokenExpiry: Date,
+  // New field to track email subscription , newletters
+  subscribedToEmails: { type: Boolean, default: true },
+  subscribedToNewsletter: { type: Boolean, default: false }
 }, {
   timestamps: true
 });


### PR DESCRIPTION
**Summary**
--
fix : #87

This PR implements an automated system to send the Problem of the Day (POTD) to subscribed users daily at 9:30 AM IST using Nodemailer and GitHub Actions.(also users can subscribe to Newsletter)



### Changes Introduced
-  Added a GitHub Actions workflow (.github/workflows/send-potd.yml) to send emails to registered users automatically daily at a fixed time without any manual need.
- Scheduled daily run at 9:30 AM IST using cron (0 4 * * * UTC)
- Triggers the deployed endpoint: https://dsa-sheet-template.vercel.app/api/send-potd

### Created API route /api/send-potd

- Connects to MongoDB and fetches users with subscribedToEmails: true (who've subscribed/registered)
- Sends dynamic POTD email with links and unsubscribe email  , subscribe to newsletter options
- Uses centralized sendEmail() method via Nodemailer

###  Integrated POTD logic via getPOTD() utility
- Dynamically loads daily problem details

### Unsubscribe / Subscribe to Newsletter system

- Users can manage preferences via links in email
- Backend route /api/email-preference handles subscription changes
- Frontend route /email-preference displays success/error messages

###  Testing
- Manually tested /api/send-potd locally 
- Verified email delivery, formatting, and unsubscribe flow
- Checked GitHub Action run log after manual dispatch

 ### Dependencies
- MongoDB (via Mongoose) , Nodemailer

### **🚀 Deployment Result** 
Emails will now be sent automatically every day without manual intervention via GitHub Actions by 
the live endpoint: https://dsa-sheet-template.vercel.app/api/send-potd






attaching a screen recorder of workflow  : 
https://screenrec.com/share/9qYRVsWjBO


Please Let me know for any other changes. 
