### PR TITLE
Fix: Improve text contrast for "Visit Profile" and "Visit Original DSAMate" in light mode

### DIFF
--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -182,7 +182,7 @@ const ContributorCard: React.FC<ContributorCardProps> = ({ contributor, index, t
           <div className="text-yellow-400 font-medium text-sm mb-2 text-center px-2">
             {contributor.login}
           </div>
-          <div className="text-white font-semibold text-sm">Click To Visit Profile</div>
+          <div className="text-gray-900 dark:text-white font-semibold text-sm">Click To Visit Profile</div>
         </div>
 
         <div className="relative mb-4 group-hover:opacity-0 transition-opacity duration-500 ease-in-out">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -576,7 +576,7 @@ export default function Home() {
                 href="https://dsamate.vercel.app"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="bg-blue-700/70 dark:bg-blue-500 backdrop-blur-sm hover:bg-white/30 text-blue-50 dark:hover:bg-blue-900/70 border border-white/30 hover:border-white/50 font-semibold py-3 px-6 sm:px-8 rounded-md transition-all duration-300 shadow-lg hover:shadow-xl transform hover:schover:bg-blue-50 dark:hover:bg-blue-900/20ale-105 w-full sm:w-auto text-sm sm:text-base"
+                className="bg-blue-700/70 dark:bg-blue-500 backdrop-blur-sm hover:bg-blue-500 text-blue-50 dark:hover:bg-blue-900/70 border border-white/30 hover:border-white/50 font-semibold py-3 px-6 sm:px-8 hover:scale-105 rounded-md transition-all duration-300 shadow-lg hover:shadow-xl transform hover:schover:bg-blue-50 dark:hover:bg-blue-900/20ale-105 w-full sm:w-auto text-sm sm:text-base"
               >
                 🔗 Visit Original DSAMate
               </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -576,7 +576,7 @@ export default function Home() {
                 href="https://dsamate.vercel.app"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="bg-white/20 backdrop-blur-sm hover:bg-white/30 text-white border border-white/30 hover:border-white/50 font-semibold py-3 px-6 sm:px-8 rounded-md transition-all duration-300 shadow-lg hover:shadow-xl transform hover:scale-105 w-full sm:w-auto text-sm sm:text-base"
+                className="bg-blue-700/70 dark:bg-blue-500 backdrop-blur-sm hover:bg-white/30 text-blue-50 dark:hover:bg-blue-900/70 border border-white/30 hover:border-white/50 font-semibold py-3 px-6 sm:px-8 rounded-md transition-all duration-300 shadow-lg hover:shadow-xl transform hover:schover:bg-blue-50 dark:hover:bg-blue-900/20ale-105 w-full sm:w-auto text-sm sm:text-base"
               >
                 🔗 Visit Original DSAMate
               </Link>


### PR DESCRIPTION
## Description
This PR addresses a text contrast issue that made certain UI elements hard to read in light mode.  

Specifically:  

- **Contributors Page**: The hover overlay text `"Visit Profile"` previously used white text, which had low visibility in light mode.  
- **Home Page**: The `"Visit Original DSAMate"` button also had white text in light mode, blending into the background and reducing readability.  

---

## Changes Made
- Updated styles for `"Visit Profile"` overlay text to ensure sufficient contrast in both light and dark modes.  
- Updated `"Visit Original DSAMate"` button text color to adapt based on theme or use a high-contrast color by default.  

---

## Screenshots
### Before (Light Mode)
<img width="1440" height="849" alt="Screenshot 2025-08-14 at 7 00 33 AM" src="https://github.com/user-attachments/assets/4d4f1930-3a24-4b07-b909-a621a3a96186" />


### After (Light Mode)
<img width="1432" height="813" alt="Screenshot 2025-08-14 at 7 00 50 AM" src="https://github.com/user-attachments/assets/5b8343ac-7ff1-4765-97bf-d32a29b91463" />

---

## How to Test
1. Switch the site to **light mode**.  
2. Go to the **Contributors** page and hover over any contributor card → text should be clearly visible.  
3. Go to the **Home** page → `"Visit Original DSAMate"` button text should have sufficient contrast.  
4. Repeat the above steps in **dark mode** to confirm no regression.

---

## Related Issue
Closes #176  

---

## Additional Notes
This fix was implemented as part of **GSSoC’25**.