### PR TITLE
Fix: Navbar Visibility on Sheet Page

### DIFF
--- a/components/NavbarSheet.tsx
+++ b/components/NavbarSheet.tsx
@@ -243,7 +243,7 @@ export default function NavbarSheet({ searchTerm, setSearchTerm, streak }: Navba
                 >
                   <span
                     className={`relative z-10 ${
-                      link.isActive ? "text-blue-400" : "text-white hover:text-blue-400"
+                      link.isActive ? "text-blue-400" : "text-gray-900 dark:text-white hover:text-blue-400"
                     }`}
                   >
                     {link.label}


### PR DESCRIPTION
## Description
This PR fixes an issue where the **navigation bar** on the `/sheet` page was **invisible by default** and only became visible when hovered over.  
This behavior caused poor usability and discoverability for users unfamiliar with the site layout.

---

## Changes Made
- Updated the navbar styling to ensure it is visible on page load.
- Applied theme-consistent colors to maintain good visibility in both light and dark modes.
- Verified that hover styles still work without hiding default visibility.
- Ensured WCAG-compliant contrast ratio for accessibility.

---

## Before
- Navbar text/icons were hidden by default.
- Only visible when hovering over the navbar area.

## After
- Navbar items are visible immediately when the page loads.
- No loss of hover interactivity.

---

## How to Test
1. Open the site in **light mode**.
2. Navigate to `/sheet` page.
3. Confirm that the navbar is visible without hovering.
4. Test in **dark mode** to ensure colors and contrast remain consistent.

---

## Related Issue
Closes #188 

---

## Additional Notes
This fix was implemented as part of **GSSoC’25**.

# Need Time
I have fixed the invisible navbar for desktop view but it is not showing the 3 lines for mobile view
