### PR TITLE
Following up previous PR Secure Daily POTD Emails

### DIFF
--- a/.github/workflows/send-potd.yml
+++ b/.github/workflows/send-potd.yml
@@ -1,13 +1,18 @@
+
 name: Send POTD Daily
 
 on:
   schedule:
     - cron: "0 4 * * *" # Runs daily at 9:30 AM IST (4:00 UTC)
   workflow_dispatch:
+concurrency:
+  group: send-potd
+  cancel-in-progress: false
 
 jobs:
   send-potd:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Call deployed endpoint
-        run: curl -X GET "https://dsa-sheet-template.vercel.app/api/send-potd"
+        run: "curl -sS --fail -X GET -H 'x-cron-secret: ${{ secrets.CRON_SECRET }}' 'https://dsa-sheet-template.vercel.app/api/send-potd'"

--- a/models/JobRun.model.ts
+++ b/models/JobRun.model.ts
@@ -1,0 +1,17 @@
+import { Schema, model, models, Document } from "mongoose";
+
+export interface IJobRun extends Document {
+  jobName: string;
+  dateKey: string;
+}
+
+const JobRunSchema = new Schema<IJobRun>({
+  jobName: { type: String, required: true },
+  dateKey: { type: String, required: true },
+}, {
+  timestamps: true
+});
+
+JobRunSchema.index({ jobName: 1, dateKey: 1 }, { unique: true });
+
+export const JobRun = models.JobRun || model<IJobRun>("JobRun", JobRunSchema);


### PR DESCRIPTION
fix : #87 — Secure Daily POTD Emails

This PR fixes the issue of **emails being sent multiple times per day** and secures the daily “Problem of the Day” (POTD) email job.

---

## Why emails were sent multiple times before

* **Public endpoint:** `GET /api/send-potd` was public. Bots, uptime monitors, and forks could trigger it.
* **Multiple callers:** Forked repos with the same GitHub Actions workflow triggered your production endpoint.
* **No idempotency:** Every request sent emails, no check if it already ran that day.

---

## What’s implemented

1. **Endpoint security**

   * Endpoint now requires header `x-cron-secret` (or query `?key=`) matching `process.env.CRON_SECRET`.
   * Unauthorized requests **won’t send emails**.

2. **Idempotent daily job**

   * Added `models/JobRun.model.ts` to track runs per day (IST).
   * If already run today, it exits without sending emails.

3. **Deduplicated recipients**

   * Uses `User.distinct('email', { subscribedToEmails: true })` to avoid duplicates from multiple user docs.

 **Result:** Daily POTD emails are now secure, idempotent, and stable.

---

## Deployment Setup

1. **Set `CRON_SECRET`** in:

   * **Hosting environment** (e.g., Vercel)
   * **GitHub repo secrets**

2. **Deploy:**

   * Forked repos won’t have your secret, so their calls are rejected.

3. **Optional test:**

```bash
curl -sS -H "x-cron-secret: YOUR_SECRET" "https://dsa-sheet-template.vercel.app/api/send-potd"
```

---

## Admin Setup (Production)

1. **Set the secret in both places:**

   * GitHub Actions Secret: `CRON_SECRET = <strong-random-secret>`
   * Hosting env (Vercel Project Settings → Environment Variables): `CRON_SECRET = <same-secret>`

2. **Confirm workflow URL** points to deployed endpoint:

   ```
   https://dsa-sheet-template.vercel.app/api/send-potd
   ```

3. **Redeploy** after setting env vars.

---

## Testing in Production

* **Manual trigger:** Use **Workflow Dispatch** in GitHub Actions or call directly:

```bash
curl -i -H "x-cron-secret: <your-prod-secret>" "https://dsa-sheet-template.vercel.app/api/send-potd"
```

### Expected responses

* **401 Unauthorized** — Missing or invalid secret, no emails sent.
* **200 “already sent today”** — Idempotency working.
* **200 “POTD emails sent successfully!”** — First run of the day.

> Tip: To resend for QA, delete today’s record from DB.

---

## Testing Locally

1. Add to `.env.local`:

```
CRON_SECRET=local-dev-secret-123
MONGO_URI=<your-uri>
GOOGLE_APP_USER=<user>
GOOGLE_APP_PASSWORD=<password>
```

2. Restart dev server:

```bash
npm run dev
```

3. Test via browser:

```
http://localhost:3000/api/send-potd?key=local-dev-secret-123
```

4. Test via terminal (PowerShell):

```powershell
Invoke-RestMethod -Uri http://localhost:3000/api/send-potd -Headers @{ "x-cron-secret" = "local-dev-secret-123" } -Method GET
```

### Expected responses

* **First run:** 200 + `{"message":"POTD emails sent successfully!"}`
* **Same day repeats:** 200 + `{"message":"POTD already sent today"}`
* **Unauthorized:** 401 if header/query secret missing or incorrect

---

## Rollback / Disable

* Safe to deploy anytime. Only scheduled workflow triggers it.
* To disable: pause GitHub Actions workflow or remove schedule.
* Rollback: revert this PR and redeploy.

---

## Checklist for Admin

* [ ] GitHub Actions `CRON_SECRET` set
* [ ] Hosting env `CRON_SECRET`, `MONGO_URI`, mail credentials set
* [ ] Manual prod test succeeds (200 + “sent successfully” once/day)
* [ ] Workflow runs successfully on schedule at **09:30 IST**

---

 My testing screenshots as ref 

First time triggering the endpoint
              <img width="1482" height="285" alt="image" src="https://github.com/user-attachments/assets/d47abbf0-049c-472a-b682-a780a5f806d5" />
              email sent only once
<img width="1403" height="724" alt="image" src="https://github.com/user-attachments/assets/7459bfe8-d5a9-45b2-80f4-5c1a93b4b0df" />


Second time triggering the endpoint 
<img width="1479" height="262" alt="image" src="https://github.com/user-attachments/assets/e53af0ad-5220-470c-a0b2-fccc23c788c6" />



---
