### PR TITLE
Added border radius for nested div

### DIFF
--- a/components/SheetContent.tsx
+++ b/components/SheetContent.tsx
@@ -295,7 +295,7 @@ export default function SheetContent({
             {/* Topic Header */}
             <button
               onClick={() => toggleTopic(topic.id)}
-              className="w-full px-4 py-3 flex justify-between items-center bg-background hover:bg-gray-100 dark:hover:bg-zinc-900 transition"
+              className="w-full px-4 py-3 flex justify-between items-center bg-background hover:bg-gray-100 dark:hover:bg-zinc-900 transition rounded-lg"
               aria-expanded={openTopics.includes(topic.id)}
               aria-controls={`topic-${topic.id}-body`}
             >
@@ -315,7 +315,7 @@ export default function SheetContent({
 
             {/* Topic Body */}
             {openTopics.includes(topic.id) && (
-              <div id={`topic-${topic.id}-body`} className="overflow-x-auto bg-background px-4 py-3">
+              <div id={`topic-${topic.id}-body`} className="overflow-x-auto bg-background px-4 py-3 rounded-lg">
                 <table className="min-w-full table-fixed text-gray-900 dark:text-white">
                   <thead>
                     <tr className="border-b border-gray-300 dark:border-gray-600">


### PR DESCRIPTION
### Related Issue(s)
* Fixes #200 

### Summary

Child components currently render with sharp edges and no border radius, creating a visual inconsistency compared to their parent containers which have rounded corners and shadows.
This PR applies consistent border radius to nested elements to ensure a unified UI.

### Changes

* Added `border-radius` to child containers.

### Screenshots 

Before:
<img width="1387" height="493" alt="Screenshot 2025-08-15 at 7 09 05 PM" src="https://github.com/user-attachments/assets/fe6d39fe-1052-400f-9f01-361727b3bc51" />

<img width="1428" height="615" alt="Screenshot 2025-08-15 at 7 06 17 PM" src="https://github.com/user-attachments/assets/779976cb-389f-4295-adcd-3d7ed0a40924" />


After : 
<img width="667" height="563" alt="Screenshot 2025-08-16 at 6 58 07 PM" src="https://github.com/user-attachments/assets/037f3aca-a56f-4d99-96b0-7fa240746728" />

### How to Test

1. Pull this branch locally.
2. Navigate to a page where nested components are rendered. (/sheet)
3. Verify that child elements now have consistent rounded corners.
### Checklist

* [x] I linked a related issue using `Fixes #<issue_number>`
* [x] I tested locally and verified the changes work as expected
* [x] I updated docs or comments where needed

