### PR TITLE
Fix: ScrollToTopBottom button appears on all pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,8 @@ import "./globals.css";
 import FooterWrapper from "@/components/FooterWrapper"; 
 import BotWidget from "@/components/BotWidget";
 import { ThemeProvider } from "@/components/theme-provider";
+import ScrollToTop from "@/components/ScrollToTopBottom";
+import ScrollToTopBottom from "@/components/ScrollToTopBottom";
 
 const plusJakarta = Plus_Jakarta_Sans({
   variable: "--font-plus-jakarta",
@@ -53,6 +55,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           {children}
+          <ScrollToTopBottom/>
         </ThemeProvider>
         <BotWidget />
         <FooterWrapper /> 

--- a/components/ScrollToTopBottom.tsx
+++ b/components/ScrollToTopBottom.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from "react";
 import { FaArrowUp, FaArrowDown } from "react-icons/fa";
 


### PR DESCRIPTION
### Related Issue(s)
- Fixes #233

### Summary
The ScrollToTopBottom button was only appearing on the Home page. This PR ensures that the button is visible on all pages by adding it to the main layout component (layout.tsx), allowing users to scroll to the top or bottom from any page.

### Changes
- Added "use client" directive to ScrollToTopBottom.tsx.
- Added <ScrollToTopBottom /> component in layout.tsx so it renders on all pages, not just Home.
- Maintained smooth scroll-to-top and scroll-to-bottom functionality.
 

### Screenshots (if applicable)
<!-- Drag & drop images or paste links -->
<img width="1920" height="1080" alt="Screenshot from 2025-08-20 08-15-30" src="https://github.com/user-attachments/assets/637c369b-9bf3-4797-93bf-85c85724a166" />


### How to Test

1. Navigate to any page (Home, Sheet, Notes, etc.) in the app.
2. Scroll down until the ScrollToTopBottom button appears.
3. Click the up or down arrow to verify smooth scrolling works correctly.

### Checklist
- [x] I linked a related issue using `Fixes #233 `
- [x] I tested locally and verified the changes work as expected
- [ ] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
