### PR TITLE
fix: reposition scroll buttons to avoid overlap with notifications

### DIFF
--- a/components/ScrollToTopBottom.tsx
+++ b/components/ScrollToTopBottom.tsx
@@ -28,7 +28,7 @@ export default function ScrollToTopBottom() {
   if (!show) return null;
 
   return (
-    <div className="fixed z-50 bottom-28 right-8 flex flex-col gap-3">
+    <div className="fixed z-50 bottom-23 left-4 flex flex-col gap-3">
       {!atBottom && (
         <button
           aria-label="Scroll to bottom"


### PR DESCRIPTION

### Related Issue(s)

* Fixes #255 
### Summary

The **Scroll to Top** and **Scroll to Bottom** buttons were overlapping with notifications in the bottom-right corner. This made notifications difficult to view and interact with.
This PR repositions the scroll buttons to the **bottom-left corner**, ensuring a cleaner and more user-friendly layout.

### Changes

* Updated button container position from `bottom-right` to `bottom-left`
* Verified alignment and spacing on different screen sizes
* Ensured accessibility and visibility in both light and dark themes

### Screenshots (if applicable)

**Before:**

<img width="1427" height="806" alt="Screenshot 2025-08-28 at 12 56 40 PM" src="https://github.com/user-attachments/assets/9ec80f43-b42f-4030-a79a-20ef9748daac" />


**After:**

<img width="1419" height="811" alt="Screenshot 2025-08-30 at 6 36 24 PM" src="https://github.com/user-attachments/assets/3df81635-b32e-4136-af38-b9022fe7d91b" />


### How to Test

1. Trigger a notification in the app (bottom-right corner).
2. Verify scroll buttons are now placed in the bottom-left corner.
3. Ensure scroll buttons function as expected (scroll to top/bottom).

### Checklist

* [x] I linked a related issue using `Fixes #<issue_number>`
* [x] I tested locally and verified the changes work as expected
* [x] I updated docs or comments where needed
