### PR TITLE
Feat: Add Company-wise Questions Page (Fixes #112)

### DIFF
--- a/app/companies/page.tsx
+++ b/app/companies/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+import Navbar from '@/components/Navbar';
+import CompanySelector from '@/components/CompanySelector';
+import CompanyQuestionsList from '@/components/CompanyQuestionsList';
+import CompanyProgressSummary from '@/components/CompanyProgressSummary';
+import { type Company } from '@/data/companyQuestions';
+
+export default function CompaniesPage() {
+  const [selectedCompany, setSelectedCompany] = useState<Company | null>(null);
+
+  const handleCompanySelect = (company: Company) => {
+    setSelectedCompany(company);
+  };
+
+  const handleBackToCompanies = () => {
+    setSelectedCompany(null);
+  };
+
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-white dark:bg-background text-gray-900 dark:text-white px-4 md:px-12 py-24 transition-colors duration-300">
+        <CompanyProgressSummary />
+        {selectedCompany ? (
+          <>
+            <CompanySelector 
+              onCompanySelect={handleBackToCompanies} 
+              selectedCompany={selectedCompany}
+            />
+            <CompanyQuestionsList 
+              questions={selectedCompany.questions}
+              companyName={selectedCompany.name}
+            />
+          </>
+        ) : (
+          <CompanySelector onCompanySelect={handleCompanySelect} />
+        )}
+      </main>
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import BotWidget from "@/components/BotWidget";
 import { ThemeProvider } from "@/components/theme-provider";
 import ScrollToTop from "@/components/ScrollToTopBottom";
 import ScrollToTopBottom from "@/components/ScrollToTopBottom";
+import { QuestionProvider } from "@/contexts/QuestionContext";
 
 const plusJakarta = Plus_Jakarta_Sans({
   variable: "--font-plus-jakarta",
@@ -54,8 +55,10 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          {children}
-          <ScrollToTopBottom/>
+          <QuestionProvider>
+            {children}
+            <ScrollToTopBottom/>
+          </QuestionProvider>
         </ThemeProvider>
         <BotWidget />
         <FooterWrapper /> 

--- a/components/CompanyProgressSummary.tsx
+++ b/components/CompanyProgressSummary.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useQuestionContext } from '@/contexts/QuestionContext';
+import { TrendingUp, Target, Star, CheckCircle } from 'lucide-react';
+
+export default function CompanyProgressSummary() {
+  const { getProgressStats } = useQuestionContext();
+  const stats = getProgressStats();
+
+  return (
+    <div className="mb-8 grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-600 dark:text-gray-400">Total Questions</p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.totalQuestions}</p>
+          </div>
+          <div className="w-8 h-8 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
+            <Target className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-600 dark:text-gray-400">Solved</p>
+            <p className="text-2xl font-bold text-green-600 dark:text-green-400">{stats.solvedQuestions}</p>
+          </div>
+          <div className="w-8 h-8 bg-green-100 dark:bg-green-900/30 rounded-lg flex items-center justify-center">
+            <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400" />
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-600 dark:text-gray-400">For Revision</p>
+            <p className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">{stats.markedForRevision}</p>
+          </div>
+          <div className="w-8 h-8 bg-yellow-100 dark:bg-yellow-900/30 rounded-lg flex items-center justify-center">
+            <Star className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-600 dark:text-gray-400">Progress</p>
+            <p className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+              {stats.progressPercentage.toFixed(1)}%
+            </p>
+          </div>
+          <div className="w-8 h-8 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center">
+            <TrendingUp className="w-4 h-4 text-purple-600 dark:text-purple-400" />
+          </div>
+        </div>
+        <div className="mt-2">
+          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+            <div 
+              className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+              style={{ width: `${stats.progressPercentage}%` }}
+            ></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/CompanyQuestionsList.tsx
+++ b/components/CompanyQuestionsList.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { type CompanyQuestion } from '@/data/companyQuestions';
+import { useQuestionContext, useQuestionsWithState } from '@/contexts/QuestionContext';
+import { ExternalLink, Clock, Tag, CheckCircle, Circle, Star, StarOff } from 'lucide-react';
+
+interface CompanyQuestionsListProps {
+  questions: CompanyQuestion[];
+  companyName: string;
+}
+
+export default function CompanyQuestionsList({ questions, companyName }: CompanyQuestionsListProps) {
+  const { updateQuestionState } = useQuestionContext();
+  const questionsWithState = useQuestionsWithState(questions);
+  const [filteredQuestions, setFilteredQuestions] = useState(questionsWithState);
+  const [difficultyFilter, setDifficultyFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [tagFilter, setTagFilter] = useState('');
+  const [frequencyFilter, setFrequencyFilter] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+
+  // Get all unique tags from questions
+  const allTags = Array.from(new Set(questions.flatMap(q => q.tags))).sort();
+
+  useEffect(() => {
+    let filtered = questionsWithState;
+
+    if (difficultyFilter) {
+      filtered = filtered.filter(q => q.difficulty === difficultyFilter);
+    }
+
+    if (statusFilter) {
+      if (statusFilter === 'solved') {
+        filtered = filtered.filter(q => q.isSolved);
+      } else if (statusFilter === 'unsolved') {
+        filtered = filtered.filter(q => !q.isSolved);
+      } else if (statusFilter === 'revision') {
+        filtered = filtered.filter(q => q.isMarkedForRevision);
+      }
+    }
+
+    if (tagFilter) {
+      filtered = filtered.filter(q => q.tags.includes(tagFilter));
+    }
+
+    if (frequencyFilter) {
+      filtered = filtered.filter(q => q.frequency === frequencyFilter);
+    }
+
+    if (searchTerm) {
+      filtered = filtered.filter(q => 
+        q.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        q.description?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        q.tags.some(tag => tag.toLowerCase().includes(searchTerm.toLowerCase()))
+      );
+    }
+
+    setFilteredQuestions(filtered);
+  }, [questionsWithState, difficultyFilter, statusFilter, tagFilter, frequencyFilter, searchTerm]);
+
+  const getDifficultyColor = (difficulty: string) => {
+    switch (difficulty) {
+      case 'easy': return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
+      case 'medium': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
+      case 'hard': return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+      default: return 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400';
+    }
+  };
+
+  const getFrequencyColor = (frequency: string) => {
+    switch (frequency) {
+      case 'very-high': return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+      case 'high': return 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400';
+      case 'medium': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
+      case 'low': return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
+      default: return 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400';
+    }
+  };
+
+  const toggleSolved = (questionId: number) => {
+    const currentState = questionsWithState.find(q => q.id === questionId);
+    updateQuestionState(questionId, { isSolved: !currentState?.isSolved });
+  };
+
+  const toggleRevision = (questionId: number) => {
+    const currentState = questionsWithState.find(q => q.id === questionId);
+    updateQuestionState(questionId, { isMarkedForRevision: !currentState?.isMarkedForRevision });
+  };
+
+  const resetFilters = () => {
+    setDifficultyFilter('');
+    setStatusFilter('');
+    setTagFilter('');
+    setFrequencyFilter('');
+    setSearchTerm('');
+  };
+
+  const solvedCount = filteredQuestions.filter(q => q.isSolved).length;
+  const progressPercentage = filteredQuestions.length > 0 ? (solvedCount / filteredQuestions.length) * 100 : 0;
+
+  return (
+    <div>
+      {/* Progress Bar */}
+      <div className="mb-6 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div className="flex justify-between items-center mb-2">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Progress</span>
+          <span className="text-sm text-gray-600 dark:text-gray-400">
+            {solvedCount} / {filteredQuestions.length} solved
+          </span>
+        </div>
+        <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+          <div 
+            className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+            style={{ width: `${progressPercentage}%` }}
+          ></div>
+        </div>
+        <div className="text-xs text-gray-500 mt-1">
+          {progressPercentage.toFixed(1)}% complete
+        </div>
+      </div>
+
+      {/* Search and Filters */}
+      <div className="mb-6 space-y-4">
+        <input
+          type="text"
+          placeholder="Search questions..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        
+        <div className="flex flex-wrap gap-4">
+          <select
+            value={difficultyFilter}
+            onChange={(e) => setDifficultyFilter(e.target.value)}
+            className="bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded px-3 py-2 border border-gray-300 dark:border-gray-600 focus:outline-none"
+          >
+            <option value="">All Difficulties</option>
+            <option value="easy">Easy</option>
+            <option value="medium">Medium</option>
+            <option value="hard">Hard</option>
+          </select>
+
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded px-3 py-2 border border-gray-300 dark:border-gray-600 focus:outline-none"
+          >
+            <option value="">All Status</option>
+            <option value="solved">Solved</option>
+            <option value="unsolved">Unsolved</option>
+            <option value="revision">Marked for Revision</option>
+          </select>
+
+          <select
+            value={tagFilter}
+            onChange={(e) => setTagFilter(e.target.value)}
+            className="bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded px-3 py-2 border border-gray-300 dark:border-gray-600 focus:outline-none"
+          >
+            <option value="">All Topics</option>
+            {allTags.map(tag => (
+              <option key={tag} value={tag}>{tag}</option>
+            ))}
+          </select>
+
+          <select
+            value={frequencyFilter}
+            onChange={(e) => setFrequencyFilter(e.target.value)}
+            className="bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded px-3 py-2 border border-gray-300 dark:border-gray-600 focus:outline-none"
+          >
+            <option value="">All Frequencies</option>
+            <option value="very-high">Very High</option>
+            <option value="high">High</option>
+            <option value="medium">Medium</option>
+            <option value="low">Low</option>
+          </select>
+
+          <button
+            onClick={resetFilters}
+            className="bg-red-500/10 border border-red-500/30 text-red-600 dark:text-red-400 rounded px-4 py-2 hover:bg-red-500/20 transition-colors"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      {/* Questions List */}
+      <div className="space-y-4">
+        {filteredQuestions.map((question) => (
+          <div
+            key={question.id}
+            className={`bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-all duration-200 ${
+              question.isSolved ? 'bg-green-50/50 dark:bg-green-900/10 border-green-200 dark:border-green-800' : ''
+            }`}
+          >
+            <div className="flex items-start justify-between mb-3">
+              <div className="flex-1">
+                <div className="flex items-center gap-3 mb-2">
+                  <button
+                    onClick={() => toggleSolved(question.id)}
+                    className="flex-shrink-0"
+                  >
+                    {question.isSolved ? (
+                      <CheckCircle className="w-5 h-5 text-green-600" />
+                    ) : (
+                      <Circle className="w-5 h-5 text-gray-400 hover:text-green-600" />
+                    )}
+                  </button>
+                  
+                  <h3 className={`font-medium text-lg ${question.isSolved ? 'line-through text-gray-500' : 'text-gray-900 dark:text-white'}`}>
+                    {question.title}
+                  </h3>
+                  
+                  <button
+                    onClick={() => toggleRevision(question.id)}
+                    className="flex-shrink-0"
+                  >
+                    {question.isMarkedForRevision ? (
+                      <Star className="w-4 h-4 text-yellow-500 fill-current" />
+                    ) : (
+                      <StarOff className="w-4 h-4 text-gray-400 hover:text-yellow-500" />
+                    )}
+                  </button>
+                </div>
+                
+                {question.description && (
+                  <p className="text-gray-600 dark:text-gray-400 text-sm mb-3">
+                    {question.description}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+              <span className={`px-2 py-1 rounded-full text-xs font-medium ${getDifficultyColor(question.difficulty)}`}>
+                {question.difficulty}
+              </span>
+              
+              <span className={`px-2 py-1 rounded-full text-xs font-medium ${getFrequencyColor(question.frequency)}`}>
+                {question.frequency} frequency
+              </span>
+              
+              {question.lastAsked && (
+                <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full text-xs flex items-center gap-1">
+                  <Clock className="w-3 h-3" />
+                  {question.lastAsked}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-1 mb-3">
+              {question.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-2 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded text-xs flex items-center gap-1"
+                >
+                  <Tag className="w-3 h-3" />
+                  {tag}
+                </span>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(question.links).map(([platform, url]) => (
+                url && (
+                  <a
+                    key={platform}
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 px-3 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors text-sm"
+                  >
+                    <ExternalLink className="w-3 h-3" />
+                    {platform}
+                  </a>
+                )
+              ))}
+              
+              {question.solutionLink && (
+                <a
+                  href={question.solutionLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 px-3 py-1 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded hover:bg-green-200 dark:hover:bg-green-900/50 transition-colors text-sm"
+                >
+                  <ExternalLink className="w-3 h-3" />
+                  Solution
+                </a>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {filteredQuestions.length === 0 && (
+        <div className="text-center py-12">
+          <div className="text-gray-400 mb-4">
+            <Circle className="w-12 h-12 mx-auto" />
+          </div>
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            No questions found
+          </h3>
+          <p className="text-gray-600 dark:text-gray-400">
+            Try adjusting your filters to see more questions.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/CompanySelector.tsx
+++ b/components/CompanySelector.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { companies, type Company } from '@/data/companyQuestions';
+import { useState } from 'react';
+import { Search, Building2, Users, TrendingUp } from 'lucide-react';
+
+interface CompanySelectorProps {
+  onCompanySelect: (company: Company) => void;
+  selectedCompany?: Company;
+}
+
+export default function CompanySelector({ onCompanySelect, selectedCompany }: CompanySelectorProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+
+  const filteredCompanies = companies.filter(company =>
+    company.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    company.description.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const getDifficultyColor = (difficulty: string) => {
+    switch (difficulty) {
+      case 'easy': return 'text-green-600 dark:text-green-400';
+      case 'medium': return 'text-yellow-600 dark:text-yellow-400';
+      case 'hard': return 'text-red-600 dark:text-red-400';
+      default: return 'text-gray-600 dark:text-gray-400';
+    }
+  };
+
+  const getFrequencyIcon = (totalQuestions: number) => {
+    if (totalQuestions >= 10) return <TrendingUp className="w-4 h-4 text-green-500" />;
+    if (totalQuestions >= 7) return <TrendingUp className="w-4 h-4 text-yellow-500" />;
+    return <TrendingUp className="w-4 h-4 text-gray-500" />;
+  };
+
+  if (selectedCompany) {
+    return (
+      <div className="mb-6">
+        <button
+          onClick={() => onCompanySelect(undefined as any)}
+          className="mb-4 text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-2"
+        >
+          ← Back to Companies
+        </button>
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+          <div className="flex items-start justify-between mb-4">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+                {selectedCompany.name}
+              </h2>
+              <p className="text-gray-600 dark:text-gray-400 mb-4">
+                {selectedCompany.description}
+              </p>
+            </div>
+            <div className="text-right">
+              <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+                {selectedCompany.totalQuestions}
+              </div>
+              <div className="text-sm text-gray-500">Questions</div>
+            </div>
+          </div>
+          
+          <div className="grid grid-cols-3 gap-4 mb-4">
+            <div className="text-center p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
+              <div className="text-lg font-semibold text-green-600 dark:text-green-400">
+                {selectedCompany.difficulty.easy}
+              </div>
+              <div className="text-sm text-gray-600 dark:text-gray-400">Easy</div>
+            </div>
+            <div className="text-center p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
+              <div className="text-lg font-semibold text-yellow-600 dark:text-yellow-400">
+                {selectedCompany.difficulty.medium}
+              </div>
+              <div className="text-sm text-gray-600 dark:text-gray-400">Medium</div>
+            </div>
+            <div className="text-center p-3 bg-red-50 dark:bg-red-900/20 rounded-lg">
+              <div className="text-lg font-semibold text-red-600 dark:text-red-400">
+                {selectedCompany.difficulty.hard}
+              </div>
+              <div className="text-sm text-gray-600 dark:text-gray-400">Hard</div>
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Popular Topics</h3>
+            <div className="flex flex-wrap gap-2">
+              {selectedCompany.popularTags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-2 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-xs rounded-full"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-8">
+      <div className="mb-6">
+        <h1 className="text-3xl md:text-4xl font-bold mb-4 text-gray-900 dark:text-white">
+          Company-wise Questions
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          Browse DSA questions asked by top tech companies. Practice company-specific problems to ace your interviews.
+        </p>
+        
+        {/* Search and View Toggle */}
+        <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
+          <div className="relative flex-1 max-w-md">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+            <input
+              type="text"
+              placeholder="Search companies..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          
+          <div className="flex gap-2">
+            <button
+              onClick={() => setViewMode('grid')}
+              className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                viewMode === 'grid'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
+              }`}
+            >
+              Grid
+            </button>
+            <button
+              onClick={() => setViewMode('list')}
+              className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                viewMode === 'list'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
+              }`}
+            >
+              List
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Companies Display */}
+      {viewMode === 'grid' ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredCompanies.map((company) => (
+            <div
+              key={company.id}
+              onClick={() => onCompanySelect(company)}
+              className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 cursor-pointer hover:shadow-lg hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-200 group"
+            >
+              <div className="flex items-start justify-between mb-4">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
+                    <Building2 className="w-5 h-5 text-white" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                      {company.name}
+                    </h3>
+                    <div className="flex items-center gap-1 text-sm text-gray-500">
+                      {getFrequencyIcon(company.totalQuestions)}
+                      <span>{company.totalQuestions} questions</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 line-clamp-2">
+                {company.description}
+              </p>
+              
+              <div className="flex justify-between items-center text-xs">
+                <div className="flex gap-3">
+                  <span className={getDifficultyColor('easy')}>
+                    {company.difficulty.easy}E
+                  </span>
+                  <span className={getDifficultyColor('medium')}>
+                    {company.difficulty.medium}M
+                  </span>
+                  <span className={getDifficultyColor('hard')}>
+                    {company.difficulty.hard}H
+                  </span>
+                </div>
+                <div className="flex items-center gap-1 text-gray-500">
+                  <Users className="w-3 h-3" />
+                  <span>Popular</span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filteredCompanies.map((company) => (
+            <div
+              key={company.id}
+              onClick={() => onCompanySelect(company)}
+              className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 cursor-pointer hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-200 group"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
+                    <Building2 className="w-4 h-4 text-white" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                      {company.name}
+                    </h3>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      {company.description}
+                    </p>
+                  </div>
+                </div>
+                
+                <div className="flex items-center gap-6 text-sm">
+                  <div className="flex gap-3">
+                    <span className={getDifficultyColor('easy')}>
+                      {company.difficulty.easy}E
+                    </span>
+                    <span className={getDifficultyColor('medium')}>
+                      {company.difficulty.medium}M
+                    </span>
+                    <span className={getDifficultyColor('hard')}>
+                      {company.difficulty.hard}H
+                    </span>
+                  </div>
+                  <div className="text-right">
+                    <div className="font-semibold text-gray-900 dark:text-white">
+                      {company.totalQuestions}
+                    </div>
+                    <div className="text-xs text-gray-500">questions</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {filteredCompanies.length === 0 && (
+        <div className="text-center py-12">
+          <Building2 className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            No companies found
+          </h3>
+          <p className="text-gray-600 dark:text-gray-400">
+            Try adjusting your search terms to find companies.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -73,6 +73,7 @@ export default function Navbar() {
     { href: "/", label: "Home", isActive: pathname === "/" },
     { href: "/notes", label: "Notes", isActive: pathname === "/notes" },
     { href: "/sheet", label: "Sheet", isActive: pathname === "/sheet" },
+    { href: "/companies", label: "Companies", isActive: pathname === "/companies" },
     { href: "/progress", label: "Progress", isActive: pathname === "/progress" },
     { href: "/contributors", label: "Contributors", isActive: pathname === "/contributors" },
     { href: "/timequiz", label: "Timed Quiz", isActive: pathname === "/timequiz" },

--- a/contexts/QuestionContext.tsx
+++ b/contexts/QuestionContext.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { type CompanyQuestion, companies as initialCompanies } from '@/data/companyQuestions';
+
+interface QuestionState {
+  [questionId: number]: {
+    isSolved: boolean;
+    isMarkedForRevision: boolean;
+  };
+}
+
+interface QuestionContextType {
+  questionStates: QuestionState;
+  updateQuestionState: (questionId: number, updates: Partial<{ isSolved: boolean; isMarkedForRevision: boolean }>) => void;
+  getQuestionState: (questionId: number) => { isSolved: boolean; isMarkedForRevision: boolean };
+  resetAllProgress: () => void;
+  getProgressStats: () => {
+    totalQuestions: number;
+    solvedQuestions: number;
+    markedForRevision: number;
+    progressPercentage: number;
+  };
+}
+
+const QuestionContext = createContext<QuestionContextType | undefined>(undefined);
+
+const STORAGE_KEY = 'company_questions_progress';
+
+export function QuestionProvider({ children }: { children: ReactNode }) {
+  const [questionStates, setQuestionStates] = useState<QuestionState>({});
+
+  // Load progress from localStorage on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        setQuestionStates(parsed);
+      }
+    } catch (error) {
+      console.error('Failed to load question progress:', error);
+    }
+  }, []);
+
+  // Save progress to localStorage whenever state changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(questionStates));
+    } catch (error) {
+      console.error('Failed to save question progress:', error);
+    }
+  }, [questionStates]);
+
+  const updateQuestionState = (questionId: number, updates: Partial<{ isSolved: boolean; isMarkedForRevision: boolean }>) => {
+    setQuestionStates(prev => ({
+      ...prev,
+      [questionId]: {
+        isSolved: prev[questionId]?.isSolved ?? false,
+        isMarkedForRevision: prev[questionId]?.isMarkedForRevision ?? false,
+        ...updates,
+      }
+    }));
+  };
+
+  const getQuestionState = (questionId: number) => {
+    return questionStates[questionId] ?? { isSolved: false, isMarkedForRevision: false };
+  };
+
+  const resetAllProgress = () => {
+    setQuestionStates({});
+    localStorage.removeItem(STORAGE_KEY);
+  };
+
+  const getProgressStats = () => {
+    // Get all unique questions across all companies
+    const allQuestions = new Set<number>();
+    initialCompanies.forEach(company => {
+      company.questions.forEach(question => {
+        allQuestions.add(question.id);
+      });
+    });
+
+    const totalQuestions = allQuestions.size;
+    let solvedQuestions = 0;
+    let markedForRevision = 0;
+
+    allQuestions.forEach(questionId => {
+      const state = getQuestionState(questionId);
+      if (state.isSolved) solvedQuestions++;
+      if (state.isMarkedForRevision) markedForRevision++;
+    });
+
+    const progressPercentage = totalQuestions > 0 ? (solvedQuestions / totalQuestions) * 100 : 0;
+
+    return {
+      totalQuestions,
+      solvedQuestions,
+      markedForRevision,
+      progressPercentage,
+    };
+  };
+
+  return (
+    <QuestionContext.Provider value={{
+      questionStates,
+      updateQuestionState,
+      getQuestionState,
+      resetAllProgress,
+      getProgressStats,
+    }}>
+      {children}
+    </QuestionContext.Provider>
+  );
+}
+
+export function useQuestionContext() {
+  const context = useContext(QuestionContext);
+  if (context === undefined) {
+    throw new Error('useQuestionContext must be used within a QuestionProvider');
+  }
+  return context;
+}
+
+// Hook to get questions with their current state
+export function useQuestionsWithState(questions: CompanyQuestion[]) {
+  const { getQuestionState } = useQuestionContext();
+  
+  return questions.map(question => ({
+    ...question,
+    ...getQuestionState(question.id),
+  }));
+}

--- a/data/companyQuestions.ts
+++ b/data/companyQuestions.ts
@@ -1,0 +1,478 @@
+export type CompanyQuestion = {
+  id: number;
+  title: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  isSolved: boolean;
+  isMarkedForRevision: boolean;
+  links: {
+    leetcode?: string;
+    gfg?: string;
+    hackerrank?: string;
+    spoj?: string;
+    ninja?: string;
+    code?: string;
+    custom?: string;
+  };
+  solutionLink?: string;
+  frequency: 'low' | 'medium' | 'high' | 'very-high'; // How frequently asked
+  lastAsked?: string; // Year when last asked
+  tags: string[]; // Topic tags like 'arrays', 'dp', 'graphs'
+  description?: string; // Brief description of the problem
+};
+
+export type Company = {
+  id: string;
+  name: string;
+  logo?: string;
+  description: string;
+  totalQuestions: number;
+  questions: CompanyQuestion[];
+  difficulty: {
+    easy: number;
+    medium: number;
+    hard: number;
+  };
+  popularTags: string[];
+};
+
+// Shared questions that appear across multiple companies
+export const sharedQuestions: CompanyQuestion[] = [
+  {
+    id: 1,
+    title: "Two Sum",
+    difficulty: "easy",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/two-sum/",
+    },
+    frequency: "very-high",
+    lastAsked: "2024",
+    tags: ["arrays", "hash-table"],
+    description: "Find two numbers in array that add up to target sum"
+  },
+  {
+    id: 2,
+    title: "Valid Parentheses",
+    difficulty: "easy",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/valid-parentheses/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["stack", "string"],
+    description: "Check if string of parentheses is valid"
+  },
+  {
+    id: 3,
+    title: "Reverse Linked List",
+    difficulty: "easy",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/reverse-linked-list/",
+    },
+    frequency: "very-high",
+    lastAsked: "2024",
+    tags: ["linked-list", "recursion"],
+    description: "Reverse a singly linked list"
+  },
+  {
+    id: 4,
+    title: "Maximum Subarray (Kadane's Algorithm)",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/maximum-subarray/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["arrays", "dynamic-programming"],
+    description: "Find contiguous subarray with largest sum"
+  },
+  {
+    id: 5,
+    title: "Binary Tree Inorder Traversal",
+    difficulty: "easy",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/binary-tree-inorder-traversal/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["tree", "dfs", "binary-tree"],
+    description: "Traverse binary tree in inorder"
+  },
+  {
+    id: 6,
+    title: "Merge Two Sorted Lists",
+    difficulty: "easy",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/merge-two-sorted-lists/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["linked-list", "recursion"],
+    description: "Merge two sorted linked lists"
+  },
+  {
+    id: 7,
+    title: "Best Time to Buy and Sell Stock",
+    difficulty: "easy",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/best-time-to-buy-and-sell-stock/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["arrays", "dynamic-programming"],
+    description: "Find maximum profit from stock prices"
+  },
+  {
+    id: 8,
+    title: "3Sum",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/3sum/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["arrays", "two-pointers"],
+    description: "Find all unique triplets that sum to zero"
+  },
+  {
+    id: 9,
+    title: "Longest Substring Without Repeating Characters",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/longest-substring-without-repeating-characters/",
+    },
+    frequency: "very-high",
+    lastAsked: "2024",
+    tags: ["string", "sliding-window", "hash-table"],
+    description: "Find length of longest substring without repeating characters"
+  },
+  {
+    id: 10,
+    title: "Add Two Numbers",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/add-two-numbers/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["linked-list", "math"],
+    description: "Add two numbers represented as linked lists"
+  }
+];
+
+// Company-specific questions (not in the main sheet)
+const googleSpecificQuestions: CompanyQuestion[] = [
+  {
+    id: 101,
+    title: "Design Search Autocomplete System",
+    difficulty: "hard",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/design-search-autocomplete-system/",
+    },
+    frequency: "medium",
+    lastAsked: "2024",
+    tags: ["design", "trie", "string"],
+    description: "Design a search autocomplete system"
+  },
+  {
+    id: 102,
+    title: "Meeting Rooms II",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/meeting-rooms-ii/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["intervals", "heap", "greedy"],
+    description: "Find minimum number of meeting rooms required"
+  },
+  {
+    id: 103,
+    title: "Word Ladder",
+    difficulty: "hard",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/word-ladder/",
+    },
+    frequency: "medium",
+    lastAsked: "2023",
+    tags: ["bfs", "string", "hash-table"],
+    description: "Find shortest transformation sequence from start to end word"
+  }
+];
+
+const amazonSpecificQuestions: CompanyQuestion[] = [
+  {
+    id: 201,
+    title: "LRU Cache",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/lru-cache/",
+    },
+    frequency: "very-high",
+    lastAsked: "2024",
+    tags: ["design", "hash-table", "linked-list"],
+    description: "Design and implement LRU cache"
+  },
+  {
+    id: 202,
+    title: "Number of Islands",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/number-of-islands/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["dfs", "bfs", "union-find", "matrix"],
+    description: "Count number of islands in 2D grid"
+  },
+  {
+    id: 203,
+    title: "Top K Frequent Elements",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/top-k-frequent-elements/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["heap", "hash-table", "bucket-sort"],
+    description: "Find k most frequent elements in array"
+  }
+];
+
+const microsoftSpecificQuestions: CompanyQuestion[] = [
+  {
+    id: 301,
+    title: "Design Tic-Tac-Toe",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/design-tic-tac-toe/",
+    },
+    frequency: "medium",
+    lastAsked: "2024",
+    tags: ["design", "array", "hash-table"],
+    description: "Design a tic-tac-toe game"
+  },
+  {
+    id: 302,
+    title: "Rotate Image",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/rotate-image/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["array", "math", "matrix"],
+    description: "Rotate n x n 2D matrix by 90 degrees"
+  }
+];
+
+const metaSpecificQuestions: CompanyQuestion[] = [
+  {
+    id: 401,
+    title: "Valid Palindrome II",
+    difficulty: "easy",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/valid-palindrome-ii/",
+    },
+    frequency: "high",
+    lastAsked: "2024",
+    tags: ["string", "two-pointers"],
+    description: "Check if string can be palindrome after deleting at most one character"
+  },
+  {
+    id: 402,
+    title: "Binary Tree Vertical Order Traversal",
+    difficulty: "medium",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/binary-tree-vertical-order-traversal/",
+    },
+    frequency: "medium",
+    lastAsked: "2024",
+    tags: ["tree", "bfs", "hash-table"],
+    description: "Return vertical order traversal of binary tree"
+  }
+];
+
+const appleSpecificQuestions: CompanyQuestion[] = [
+  {
+    id: 501,
+    title: "Serialize and Deserialize Binary Tree",
+    difficulty: "hard",
+    isSolved: false,
+    isMarkedForRevision: false,
+    links: {
+      leetcode: "https://leetcode.com/problems/serialize-and-deserialize-binary-tree/",
+    },
+    frequency: "medium",
+    lastAsked: "2024",
+    tags: ["tree", "dfs", "bfs", "design"],
+    description: "Design algorithm to serialize and deserialize binary tree"
+  }
+];
+
+// Helper function to combine shared questions with company-specific ones
+const combineQuestions = (specificQuestions: CompanyQuestion[], sharedQuestionIds: number[]) => {
+  const shared = sharedQuestions.filter(q => sharedQuestionIds.includes(q.id));
+  return [...shared, ...specificQuestions];
+};
+
+export const companies: Company[] = [
+  {
+    id: "google",
+    name: "Google",
+    description: "Search, Cloud, Android, and AI technologies",
+    totalQuestions: 0,
+    questions: combineQuestions(googleSpecificQuestions, [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    difficulty: { easy: 0, medium: 0, hard: 0 },
+    popularTags: ["arrays", "string", "tree", "design", "dynamic-programming"]
+  },
+  {
+    id: "amazon",
+    name: "Amazon",
+    description: "E-commerce, Cloud Computing (AWS), and Digital Streaming",
+    totalQuestions: 0,
+    questions: combineQuestions(amazonSpecificQuestions, [1, 2, 3, 4, 6, 7, 8, 9, 10]),
+    difficulty: { easy: 0, medium: 0, hard: 0 },
+    popularTags: ["arrays", "tree", "design", "dfs", "dynamic-programming"]
+  },
+  {
+    id: "microsoft",
+    name: "Microsoft",
+    description: "Software, Cloud Services, and Gaming",
+    totalQuestions: 0,
+    questions: combineQuestions(microsoftSpecificQuestions, [1, 2, 3, 4, 5, 7, 8, 9]),
+    difficulty: { easy: 0, medium: 0, hard: 0 },
+    popularTags: ["arrays", "string", "tree", "design", "math"]
+  },
+  {
+    id: "meta",
+    name: "Meta (Facebook)",
+    description: "Social Media, VR/AR, and Metaverse Technologies",
+    totalQuestions: 0,
+    questions: combineQuestions(metaSpecificQuestions, [1, 2, 3, 4, 5, 6, 8, 9]),
+    difficulty: { easy: 0, medium: 0, hard: 0 },
+    popularTags: ["arrays", "string", "tree", "hash-table", "two-pointers"]
+  },
+  {
+    id: "apple",
+    name: "Apple",
+    description: "Consumer Electronics, Software, and Services",
+    totalQuestions: 0,
+    questions: combineQuestions(appleSpecificQuestions, [1, 2, 3, 4, 5, 6, 7, 9]),
+    difficulty: { easy: 0, medium: 0, hard: 0 },
+    popularTags: ["arrays", "tree", "string", "design", "linked-list"]
+  },
+  {
+    id: "netflix",
+    name: "Netflix",
+    description: "Streaming Entertainment and Content Production",
+    totalQuestions: 0,
+    questions: combineQuestions([], [1, 2, 4, 6, 7, 8, 9]),
+    difficulty: { easy: 0, medium: 0, hard: 0 },
+    popularTags: ["arrays", "string", "dynamic-programming", "design"]
+  },
+  {
+    id: "uber",
+    name: "Uber",
+    description: "Ride-sharing, Food Delivery, and Logistics",
+    totalQuestions: 0,
+    questions: combineQuestions([], [1, 2, 3, 4, 7, 8, 9, 10]),
+    difficulty: { easy: 0, medium: 0, hard: 0 },
+    popularTags: ["arrays", "string", "design", "graph", "greedy"]
+  },
+  {
+    id: "linkedin",
+    name: "LinkedIn",
+    description: "Professional Networking and Career Development",
+    totalQuestions: 0,
+    questions: combineQuestions([], [1, 2, 3, 5, 6, 7, 8]),
+    difficulty: { easy: 0, medium: 0, hard: 0 },
+    popularTags: ["arrays", "string", "tree", "design", "hash-table"]
+  }
+];
+
+// Calculate difficulty distribution and total questions for each company
+companies.forEach(company => {
+  company.totalQuestions = company.questions.length;
+  company.difficulty = company.questions.reduce(
+    (acc, q) => {
+      acc[q.difficulty]++;
+      return acc;
+    },
+    { easy: 0, medium: 0, hard: 0 }
+  );
+});
+
+// Helper function to get company by id
+export const getCompanyById = (id: string): Company | undefined => {
+  return companies.find(company => company.id === id);
+};
+
+// Helper function to get all unique tags
+export const getAllTags = (): string[] => {
+  const tagSet = new Set<string>();
+  companies.forEach(company => {
+    company.questions.forEach(question => {
+      question.tags.forEach(tag => tagSet.add(tag));
+    });
+  });
+  return Array.from(tagSet).sort();
+};
+
+// Helper function to search questions across all companies
+export const searchQuestionsAcrossCompanies = (searchTerm: string): { company: Company; question: CompanyQuestion }[] => {
+  const results: { company: Company; question: CompanyQuestion }[] = [];
+  
+  companies.forEach(company => {
+    company.questions.forEach(question => {
+      if (
+        question.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        question.tags.some(tag => tag.toLowerCase().includes(searchTerm.toLowerCase())) ||
+        question.description?.toLowerCase().includes(searchTerm.toLowerCase())
+      ) {
+        results.push({ company, question });
+      }
+    });
+  });
+  
+  return results;
+};


### PR DESCRIPTION
### Related Issue(s)
- Fixes #112

### Summary
Implemented the *Company-wise Questions Page*.

This PR adds a dedicated page where users can browse DSA questions company-wise.  
Users can select a company (Google, Amazon, Microsoft, etc.) and view all relevant questions.  
Dummy data is used initially, and the "Mark as Done" status is synced across companies.

### Changes
- Added company selector UI .
- Displayed dummy company-wise question lists.
- Synced "Mark as Done" status across companies.
- Built modular, reusable components for scalability.

### Screenshots (if applicable)
<img width="1920" height="1080" alt="Screenshot from 2025-09-03 17-04-37" src="https://github.com/user-attachments/assets/7a267edc-4331-4727-83fb-39ebfc815fab" />

### How to Test
1. Navigate to the `Company-wise Questions Page`.
2. Select a company (e.g., Google, Amazon).
3. Verify that relevant dummy questions are displayed.
4. Mark a question as done and confirm it reflects across companies where it exists.

### Checklist
- [x] I linked a related issue using `Fixes #112`
- [x] I tested locally and verified the changes work as expected
- [x] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
