### PR TITLE
Fixed the logic for calling of confetti in progress tracker and sheet page

### DIFF
--- a/components/ProgressTracker.tsx
+++ b/components/ProgressTracker.tsx
@@ -16,26 +16,7 @@ const ProgressTracker: React.FC<ProgressTrackerProps> = ({
 }) => {
   const percent = (solvedQuestions / totalQuestions) * 100;
 
-  React.useEffect(() => {
-    if (isCompleted) {
-      // Dynamically import so it's only loaded in browser (fixes Vercel SSR issue)
-      import('canvas-confetti').then((confetti) => {
-        confetti.default({
-          particleCount: 300,
-          spread: 100,
-          origin: { y: 0.6 },
-        });
-      });
-
-      // Toast message
-      const toast = document.createElement('div');
-      toast.className =
-        'toast fixed top-5 right-5 bg-green-500 text-white px-4 py-2 rounded-lg shadow-md z-50';
-      toast.textContent = `Congrats! You've completed "${topicName}" 🎉`;
-      document.body.appendChild(toast);
-      setTimeout(() => toast.remove(), 3000);
-    }
-  }, [isCompleted, topicName]);
+  // Celebration side-effects moved to SheetContent to avoid firing on every page visit.
 
   return (
     <div className="mt-4">

--- a/components/SheetContent.tsx
+++ b/components/SheetContent.tsx
@@ -241,6 +241,26 @@ export default function SheetContent({
         if (!topic) continue;
 
         try {
+          // Fire celebration ONLY for brand-new completion (not stored previously)
+          // Confetti (dynamic import for CSR only)
+          import('canvas-confetti').then((confetti) => {
+            confetti.default({
+              particleCount: 250,
+              spread: 90,
+              origin: { y: 0.6 },
+            });
+          }).catch(() => { });
+
+          // Lightweight toast (no external lib; ephemeral div)
+          const toast = document.createElement('div');
+          toast.className = 'fixed top-5 right-5 bg-green-600 text-white px-4 py-2 rounded-lg shadow-md z-[9999] text-sm animate-fade-in';
+          toast.textContent = `Congrats! You've completed "${topic.name}" 🎉`;
+          document.body.appendChild(toast);
+          setTimeout(() => {
+            toast.classList.add('opacity-0', 'transition-opacity', 'duration-500');
+            setTimeout(() => toast.remove(), 600);
+          }, 2600);
+
           if (isLoggedIn && user) {
             await sendProgressUpdate({
               questionDifficulty: null,
@@ -356,7 +376,7 @@ export default function SheetContent({
             >
               <span className="text-lg font-medium text-gray-900 dark:text-white">{topic.name}</span>
               <span className="text-sm text-gray-500 dark:text-gray-400 font-medium px-2 py-2 ml-auto">
-              {<ProgressTracker
+                {<ProgressTracker
                   totalQuestions={totalQ}
                   solvedQuestions={solvedQ}
                   topicName={topic.name}
@@ -577,4 +597,3 @@ export default function SheetContent({
     </>
   );
 }
- 


### PR DESCRIPTION
### Related Issue(s)
- Fixes #305

### Summary
Previously, celebration effects (toast + confetti) were automatically triggered from `ProgressTracker`, which caused repeat celebrations even after page reloads.  
This PR refactors the logic so celebrations only fire when a topic is newly completed, ensuring a cleaner and more intentional user experience.

### Changes
- Removed automatic celebration side-effects from `ProgressTracker`.
- Moved celebration logic into `SheetContent` completion detection effect.
- Celebration now triggers **only** for topics transitioning to completed (new completions since last persisted state).
- Added lightweight inline toast for completion feedback.
- Dynamically imported `canvas-confetti` for improved performance.
- Verified persistence of completed topics (no duplicate celebrations on reload).

### Screenshots (if applicable)
<!-- Drag & drop images or paste links here -->

### How to Test
1. Run the app locally and open the **SheetContent** page.
2. Mark a topic as completed → verify toast + confetti trigger only once.
3. Refresh the page → verify completed topics persist without retriggering celebration.
4. Mark another new topic as completed → verify celebration works again.

### Checklist
- [ ] I linked a related issue using `Fixes #305`
- [ ] I tested locally and verified the changes work as expected
- [ ] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
