### PR TITLE
Improved visibility of Terms of Service and Privacy Policy button

### DIFF
--- a/app/privacy-terms/page.tsx
+++ b/app/privacy-terms/page.tsx
@@ -85,7 +85,7 @@ function PrivacyTermsContent() {
                 className={`px-6 py-3 rounded-lg font-medium transition-all duration-300 ${
                   activeTab === 'privacy'
                     ? 'bg-gradient-to-r from-blue-500 to-purple-500 text-white shadow-lg'
-                    : 'text-gray-400 hover:text-foreground dark:hover:text-white'
+                    : 'text-gray-800 hover:text-white'
                 }`}
               >
                 Privacy Policy
@@ -95,7 +95,7 @@ function PrivacyTermsContent() {
                 className={`px-6 py-3 rounded-lg font-medium transition-all duration-300 ${
                   activeTab === 'terms'
                     ? 'bg-gradient-to-r from-blue-500 to-purple-500 text-white shadow-lg'
-                    : 'text-gray-400 hover:text-foreground dark:hover:text-white'
+                    : 'text-gray-800 hover:text-white'
                 }`}
               >
                 Terms of Service
@@ -112,7 +112,7 @@ function PrivacyTermsContent() {
             className="bg-gradient-to-br from-purple-500/10 to-blue-500/10 rounded-2xl p-8 border border-white/10 dark:border-white/10 border-gray-200"
           >
             {activeTab === 'privacy' ? (
-              <div className="prose prose-gray dark:prose-invert max-w-none">
+              <div className="prose max-w-none text-foreground">
                 <h2 className="text-2xl font-bold mb-6 text-purple-600 dark:text-purple-400">Privacy Policy</h2>
                 <p className="text-gray-700 dark:text-gray-300 mb-4">
                   <strong>Last updated:</strong> {new Date().toLocaleDateString()}


### PR DESCRIPTION
### Related Issue(s)
- Fixes #308

### Summary
The "Terms of Service" and "Privacy Policy" links were previously a light grey color, which blended with the background and made them hard to read. This PR updates the text color to text-gray-800 to improve visibility and accessibility.

### Changes
Updated the text color of "Terms of Service" and "Privacy Policy" links from grey to text-gray-800

### Screenshots (if applicable)
before:
<img width="523" height="159" alt="Screenshot 2025-09-12 001110" src="https://github.com/user-attachments/assets/6e6b4a42-6041-4489-82a2-9ec972ab2e2c" />

after:
<img width="520" height="150" alt="Screenshot 2025-09-12 002041" src="https://github.com/user-attachments/assets/6c9229af-2dea-454f-9a5c-d5d67315b743" />


### How to Test
1. Open the website locally
2. Navigate to the page containing "Terms of Service" and "Privacy Policy" links
3. Verify that the links are now clearly visible and readable

### Checklist
- ✅ I linked a related issue using `Fixes #<issue_number>`
- ✅ I tested locally and verified the changes work as expected
- ✅ I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
