### PR TITLE
Fix: corrected Input component background transparency issue

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,8 +8,15 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "text-black",
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "text-gray-900", // darker input text
+        "placeholder:text-gray-600", // darker placeholder text
+        "file:text-foreground selection:bg-primary selection:text-primary-foreground",
+        "dark:bg-input/30",
+        "flex h-9 w-full min-w-0 rounded-md border border-black", // solid black border
+        "bg-white", // solid background instead of transparent
+        "px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none",
+        "file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium",
+        "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
@@ -20,3 +27,4 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 }
 
 export { Input }
+


### PR DESCRIPTION
### Related Issue(s)
- Fixes #330 

### Summary
The signup page input fields looked transparent, making the text box hard to see. This PR fixes the issue by adding a proper background and border styling. Additionally, the placeholder text color was too light, so it has been darkened for better visibility.

### Changes
- Updated Input component (components/ui/input.tsx) to add a solid white background with dark borders.
- Adjusted placeholder text color to be darker and more readable.
- Improved overall input styling to ensure consistent visibility across light/dark modes.

### Screenshots (if applicable)
Before
<img width="615" height="818" alt="Screenshot 2025-09-15 222522" src="https://github.com/user-attachments/assets/cf2807ce-2ea8-4204-b6fc-35907750562e" />
After
<img width="948" height="890" alt="Screenshot 2025-09-16 195147" src="https://github.com/user-attachments/assets/e349ab2b-0e17-4a61-bfb0-8cc616a85518" />
<img width="950" height="894" alt="Screenshot 2025-09-16 195442" src="https://github.com/user-attachments/assets/241afd82-3be3-4a91-b92c-995393debb64" />
### How to Test
1. Go to the signup page.
2. Check that input fields now have a solid background and visible border.
3. Verify that placeholder text is darker and readable.

### Checklist
- [x] I linked a related issue using `Fixes #330`
- [x] I tested locally and verified the changes work as expected
- [x] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
