### PR TITLE
feat: Added Post Route for questions

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,6 +1,5 @@
 import { Brain, Star, Zap } from "lucide-react";
 import Image from "next/image";
-import banner from "../../public/assets/banner.png";
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col md:flex-row min-h-screen bg-black  animate-in fade-in slide-in-from-bottom-6">
@@ -9,7 +8,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
       <div
         className="hidden md:flex md:flex-col md:w-1/2 text-white p-10 justify-center space-y-6 relative transition-all duration-300 rounded-r-2xl h-screen "
         style={{
-          backgroundImage: `url(${banner.src})`,
+          backgroundImage: `url(/assets/banner.png)`,
           backgroundSize: "cover",
           backgroundPosition: "center",
           backgroundRepeat: "no-repeat",
@@ -17,29 +16,29 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
       >
         <div className=" bg-transparent backdrop-blur-2xl border-2 rounded-3xl flex flex-col justify-center items-center py-6">
 
-        <div className="flex flex-col items-center text-center space-y-2">
-          <Image
-        src={"/icons/icon-192.png"}
-        alt="DSAMate Logo"
-        width={150}
-        height={130}
-        className="mb-10  shake-hover"
-        />
-          <h1 className="text-2xl lg:text-3xl font-bold leading-tight">Make it to DSA</h1>
-          <p className="text-base text-white/90 max-w-sm">Get all DSA problems here to boost your career.</p>
-        </div>
+          <div className="flex flex-col items-center text-center space-y-2">
+            <Image
+              src={"/icons/icon-192.png"}
+              alt="DSAMate Logo"
+              width={150}
+              height={130}
+              className="mb-10  shake-hover"
+            />
+            <h1 className="text-2xl lg:text-3xl font-bold leading-tight">Make it to DSA</h1>
+            <p className="text-base text-white/90 max-w-sm">Get all DSA problems here to boost your career.</p>
+          </div>
 
-        <div className="space-y-6 mt-10">
-          <FeatureItem icon={<Zap className="text-black" />} title="Smooth User Expirence" desc="Find your problem to get started with." />
-          <FeatureItem icon={<Brain className="text-black" />} title="Question Index" desc="All questions in one place." />
-          <FeatureItem icon={<Star className="text-black" />} title="Smart Insights" desc="AI helps to make your progress better." />
-        </div>
+          <div className="space-y-6 mt-10">
+            <FeatureItem icon={<Zap className="text-black" />} title="Smooth User Expirence" desc="Find your problem to get started with." />
+            <FeatureItem icon={<Brain className="text-black" />} title="Question Index" desc="All questions in one place." />
+            <FeatureItem icon={<Star className="text-black" />} title="Smart Insights" desc="AI helps to make your progress better." />
+          </div>
         </div>
       </div>
 
       {/* Right Side: Auth Form */}
       <div className="flex flex-col w-full md:w-1/2 justify-center items-center p-6 sm:p-8 md:h-screen">
-        <Image src={"/icons/icon-192.png"} alt="DSAMate logo" width={100} height={100} className="block md:hidden m-5 w-[100px] h-[100px]"/>
+        <Image src={"/icons/icon-192.png"} alt="DSAMate logo" width={100} height={100} className="block md:hidden m-5 w-[100px] h-[100px]" />
         <div className="w-full max-w-md">
           {children}
         </div>

--- a/app/api/questions/README.md
+++ b/app/api/questions/README.md
@@ -1,0 +1,64 @@
+POST /api/questions
+
+This route accepts POST requests to add or update questions/topics in the MongoDB `questions` collection.
+
+Authentication
+
+- The route requires a logged-in user (session cookie named `session` containing a JWT). Any authenticated user can add or update topics/questions.
+
+Supported payloads
+
+1. Upsert an entire topic
+   {
+   "topic": {
+   "id": 101,
+   "name": "Arrays",
+   "questions": [
+   { "id": 1001, "title": "Two Sum", "difficulty": "easy", "links": { "leetcode": "..." }, "companies": ["Google"] }
+   ]
+   }
+   }
+
+2. Add a question to an existing topic
+   {
+   "topicId": 101,
+   "question": { "id": 1002, "title": "Three Sum", "difficulty": "medium" }
+   }
+
+Validation
+
+- question.id: number
+- question.title: non-empty string
+- question.difficulty: one of "easy", "medium", "hard"
+- question.links: optional object
+- question.companies: optional array of strings
+
+Responses
+
+- 200: success with updated topic (for topic upsert)
+- 201: question added to topic
+- 400: invalid payload
+- 401: unauthenticated
+- 403: forbidden (if user record cannot be found)
+- 404: topic not found
+- 409: duplicate question id
+- 500: server error
+
+Notes
+
+Notes
+
+- Currently only authentication is required. If you later want admin-only access, we can add a role flag (e.g. `isAdmin`) to the `User` schema and check it here.
+- Ensure `JWT_SECRET` is set in environment when running locally or in production.
+
+Try it (example)
+
+Use your browser or an HTTP client that preserves cookies (the server expects a `session` cookie). If you already have a session cookie set in your browser you can run this from the same host.
+
+Example curl (if you have the session cookie value):
+
+curl -X POST \
+ -H "Content-Type: application/json" \
+ -b "session=<JWT_SESSION_TOKEN>" \
+ -d '{"topicId":101,"question":{"id":1003,"title":"Sample","difficulty":"easy"}}' \
+ http://localhost:3000/api/questions

--- a/app/api/questions/route.ts
+++ b/app/api/questions/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { connect } from "../../../db/config";
 import { Topic } from "../../../models/Question.model";
 import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
+import { User } from "../../../models/User.model";
 
 export async function GET(request: NextRequest) {
     try {
@@ -98,6 +100,91 @@ export async function GET(request: NextRequest) {
             },
             { status: 500 }
         );
+    }
+}
+
+// Helper: verify session cookie and ensure requester is admin
+async function getSessionUserId(req: NextRequest) {
+    const token = req.cookies.get("session")?.value;
+    if (!token) return null;
+    try {
+        const decoded = jwt.verify(token, process.env.JWT_SECRET!) as any;
+        return decoded?.id || null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function validateQuestion(q: any) {
+    if (!q) return "Question object is required";
+    if (typeof q.id !== 'number') return "question.id must be a number";
+    if (typeof q.title !== 'string' || q.title.trim() === '') return "question.title must be a non-empty string";
+    if (!['easy', 'medium', 'hard'].includes(q.difficulty)) return "question.difficulty must be one of: easy, medium, hard";
+    if (q.links && typeof q.links !== 'object') return "question.links must be an object";
+    if (q.companies && !Array.isArray(q.companies)) return "question.companies must be an array of strings";
+    return null;
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        await connect();
+
+        // Admin check: require a logged-in user and ADMIN_EMAIL to match
+        const userId = await getSessionUserId(request);
+        if (!userId) {
+            return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+        }
+
+        const user = await User.findById(userId).lean() as any;
+        if (!user) {
+            return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+        }
+
+        const body = await request.json();
+
+        // Support adding either a full topic or a question to an existing topic
+        // If body.topic is present, expect { id, name, questions }
+        if (body.topic) {
+            const t = body.topic;
+            if (typeof t.id !== 'number' || typeof t.name !== 'string' || !Array.isArray(t.questions)) {
+                return NextResponse.json({ success: false, error: 'Invalid topic payload' }, { status: 400 });
+            }
+
+            // Validate each question
+            for (const q of t.questions) {
+                const err = validateQuestion(q);
+                if (err) return NextResponse.json({ success: false, error: err }, { status: 400 });
+            }
+
+            // Upsert topic by id
+            const updated = await Topic.findOneAndUpdate({ id: t.id }, { $set: { name: t.name, questions: t.questions } }, { upsert: true, new: true, setDefaultsOnInsert: true }).lean();
+            return NextResponse.json({ success: true, data: updated }, { status: 200 });
+        }
+
+        // If body.question + topicId provided, add question to existing topic
+        if (body.question && typeof body.topicId === 'number') {
+            const q = body.question;
+            const err = validateQuestion(q);
+            if (err) return NextResponse.json({ success: false, error: err }, { status: 400 });
+
+            const topic = await Topic.findOne({ id: body.topicId });
+            if (!topic) return NextResponse.json({ success: false, error: 'Topic not found' }, { status: 404 });
+
+            // prevent duplicate question id
+            if (topic.questions.some((qq: any) => qq.id === q.id)) {
+                return NextResponse.json({ success: false, error: 'Question with this id already exists in topic' }, { status: 409 });
+            }
+
+            topic.questions.push(q);
+            await topic.save();
+            return NextResponse.json({ success: true, data: topic }, { status: 201 });
+        }
+
+        return NextResponse.json({ success: false, error: 'Invalid payload. Provide either { topic } or { topicId, question }' }, { status: 400 });
+
+    } catch (error: any) {
+        console.error('Error in POST /api/questions', error);
+        return NextResponse.json({ success: false, error: error.message || 'Internal server error' }, { status: 500 });
     }
 }
 


### PR DESCRIPTION

### Related Issue(s)

* Fixes #324

### Summary

Added a **POST endpoint at `/api/questions`** for upserting topics or adding questions.
Requires authentication (JWT session cookie).
Added runtime validation for payloads, updated docs, and fixed a TypeScript static image import error.

### Changes

* **route.ts**

  * Added POST handler with payload validation, auth check, and upsert/add logic.
  * Returns appropriate error codes (400/401/403/404/409/500).
* **README.md**

  * Added usage docs with example payloads and a `curl` test command.
* **layout.tsx**

  * Removed static image import.
  * Updated backgroundImage to `url(/assets/banner.png)` to fix TS2307 image import error.

### Screenshots (if applicable)

<!-- Add screenshot of new banner rendering or sample curl output -->  

### How to Test

1. Start dev server and log in as any user to obtain session cookie (JWT).
2. Run `npx tsc --noEmit` — confirm no TypeScript errors.
3. Test with curl (example):

   ```bash
   curl -X POST \
   -H "Content-Type: application/json" \
   -b "session=<JWT_SESSION_TOKEN>" \
   -d '{"topicId":101,"question":{"id":1003,"title":"Sample","difficulty":"easy"}}' \
   http://localhost:3000/api/questions
   ```

   * Expected: `201` Created (question added).

### Checklist

* [x] I linked a related issue using `Fixes #324 `
* [x] I tested locally and verified the changes work as expected
* [x] I updated docs or comments where needed

---

⚠️ **Notes / Risks**

* Current auth model allows *any authenticated user* to add questions (admin-only can be added later via `isAdmin`).
* Ensure `/public/assets/banner.png` exists in production to avoid a 404.
* Server schema unchanged; only client and route changes.

---

