### PR TITLE
[update]-updated the readme.md learn.md files according to the project requirements.

### DIFF
--- a/LEARN.md
+++ b/LEARN.md
@@ -1,15 +1,13 @@
-# DSAMate Template – GSSoC '25
-
-🚀 This repository is a **template version** of [DSAMate](https://dsamate.vercel.app) — your all-in-one platform for practicing DSA (Data Structures & Algorithms) questions.  
-This version is open for contributions as a part of **GirlScript Summer of Code (GSSoC) 2025**.
-
-> ⚠️ **Note:** This is **not the original DSAMate sheet**. It is meant to serve as a public base for open-source contributions.
+# DSAMate v2 – GSSoC '25
 
 ---
 
 ## 🔍 About the Project
 
-DSAMate Template helps contributors explore the frontend logic, filters, UI components, and page structure of a full-featured DSA practice site.
+🚀 This repository is **DSAMate v2** — your all-in-one platform for practicing Data Structures & Algorithms (DSA) questions.
+It is open for contributions under **GirlScript Summer of Code (GSSoC) 2025**.
+
+The live project is available here [DSAMate v2](https://dsamate-v2.vercel.app)
 
 ---
 
@@ -38,13 +36,9 @@ Please read the [CONTRIBUTIONS](CONTRIBUTING.md) if you're a contributor.
 - **React Icons**
 ---
 
-## 🌐 Original DSAMate Website
+## 🌐 DSAMate v2 Website
 
-Looking for the actual live version with the complete list of real DSA questions and features?
-
----
-
-👉 [**Visit DSAMate Original**](https://dsamate.vercel.app)  
+👉 [**Visit DSAMate v2**](https://dsamate-v2.vercel.app)  
 _(Includes 450+ topic-wise questions with solutions, filters, and daily practice features.)_
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,17 +20,14 @@
   </p>
 </div>
 
-🚀 This repository is a **template version** of [DSAMate](https://dsamate.vercel.app) — your all-in-one platform for practicing DSA (Data Structures & Algorithms) questions.  
-This version is open for contributions as a part of **GirlScript Summer of Code (GSSoC) 2025**.
-
-> 🚧 **Disclaimer:** This repository is a **template clone** created for open-source learning under GSSoC '25.  
-> It uses only placeholder content and UI logic — **no real DSA questions are included**.  
-> The **real DSAMate site** with full question lists is live at [dsamate.vercel.app](https://dsamate.vercel.app).
-
-
 ## 🔍 About the Project
 
-DSAMate v2 helps contributors explore the frontend logic, filters, UI components, and page structure of a full-featured DSA practice site.
+**DSAMate v2** is a one-stop platform for practicing Data Structures & Algorithms (DSA) questions.
+Built with a focus on learning and contribution, this project offers an interactive UI, smart question filters, and daily practice features. It includes **450+ topic-wise questions with solutions** to help learners strengthen their DSA skills.
+
+As part of **GirlScript Summer of Code (GSSoC) 2025**, the project is open to contributors who want to explore, improve, and expand the features of DSAMate.
+
+The live project is available at [dsamate-v2.vercel.app](https://dsamate-v2.vercel.app).
 
 
 ### 🌟 Features
@@ -220,20 +217,6 @@ Please read the [CONTRIBUTING GUIDELINES](CONTRIBUTING.md) if you're a contribut
 └─ 📄 tsconfig.json          # TypeScript config
 
 ```
-
-
-## 🌐 Original DSAMate Website
-
-Looking for the actual live version with the complete list of real DSA questions and features?
-
-
----
-> ⚠️ **NOTE:** The link below is for the official, fully functional DSAMate site — not this template project.
-
-
-
-👉 [**Visit DSAMate Original**](https://dsamate.vercel.app)  
-_(Includes 450+ topic-wise questions with solutions, filters, and daily practice features.)_
 
 ---
 


### PR DESCRIPTION
### Related Issue(s)

### Fixes #338

### Summary

This PR updates the project documentation to reflect the correct project name. The term “DSAMate Template” has been replaced with “DSAMate v2” across relevant files. The context of the documentation has also been restructured to represent DSAMate v2 as the unique and contributor-friendly project under GSSoC 2025.

### Changes

- Updated README.md to replace all mentions of “DSAMate Template” with “DSAMate v2”
- Updated learn.md with the new project name and context
- Removed references that implied the repo was just a template
- Improved wording to highlight DSAMate v2 as the main project open for contributions

Screenshots 

### How to Test

1.Open the updated README.md and confirm that all instances of “DSAMate Template” are now “DSAMate v2”

2.Review learn.md to ensure the context matches the new project identity

3.Verify that no outdated template references remain


### Checklist
- [x] I linked a related issue using `Fixes #338 `
- [x] I tested locally and verified the changes work as expected
- [x] I updated docs or comments where needed

### Labels  GSSoC 2025 
