### PR TITLE
fixed the alignment issue in the footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -368,24 +368,25 @@ export default function Footer() {
           transition={{ duration: 0.6, delay: 0.4 }}
           className="relative z-10 border-t border-border mt-12 pt-6 text-center"
         >
-          <div className="flex flex-col md:flex-row justify-between items-center gap-3">
-            <p className="text-sm text-muted-foreground">
-              &copy; {new Date().getFullYear()} DSA Practice. All Rights
-              Reserved.
-            </p>
-            <p className="text-xs text-muted-foreground flex items-center gap-2">
-              Made with <span className="text-red-500 animate-pulse">❤️</span>{" "}
-              by{" "}
-              <motion.a
-                href="https://github.com/saumyayadav25"
-                target="_blank"
-                rel="noopener noreferrer"
-                whileHover={{ scale: 1.05 }}
-                className="text-blue-500 hover:text-blue-600 font-medium transition-colors"
-              >
-                Saumya Yadav
-              </motion.a>
-            </p>
+          <div className="flex flex-col md:flex-row justify-center items-center gap-3">
+            <div className="flex flex-col md:flex-row justify-center items-center gap-2 text-sm text-muted-foreground">
+              <span>
+                &copy; {new Date().getFullYear()} DSA Practice. All Rights Reserved.
+              </span>
+              <span className="hidden md:inline-block mx-2">|</span>
+              <span className="flex items-center gap-2">
+                Made with <span className="text-red-500 animate-pulse">❤️</span> by{" "}
+                <motion.a
+                  href="https://github.com/saumyayadav25"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  whileHover={{ scale: 1.05 }}
+                  className="text-blue-500 hover:text-blue-600 font-medium transition-colors"
+                >
+                 Saumya Yadav
+                </motion.a>
+              </span>
+            </div>
           </div>
         </motion.div>
       </footer>


### PR DESCRIPTION
### Related Issue(s)
- Fixes #<344>

### Summary
Updated footer layout to centre copyright and attribution text with a pipe separator between them for better visual balance.

### Changes
- Centered copyright and "Made with ❤️" text in footer.
- Added pipe separator (|) between the two text sections.


### Screenshots (if applicable)
<img width="1892" height="236" alt="image" src="https://github.com/user-attachments/assets/03a09317-a4fb-4be1-bde9-ff17afea8492" />


### How to Test
1. Scroll to footer and verify text is centered.
2. Check pipe separator appears between copyright and attribution.

### Checklist
- [ ] I linked a related issue using `Fixes #<344>`
- [ ] I tested locally and verified the changes work as expected


> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
