### PR TITLE
Improved footer UI layout

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -97,7 +97,7 @@ export default function Footer() {
               <span className="bg-gradient-to-r from-blue-500 to-cyan-500 w-3 h-3 rounded-full"></span>
               Quick Links
             </h3>
-            <ul className="space-y-3">
+            <ul className="space-y-3 list-none p-0 m-0">
               {[
                 { href: "/", label: "Home" },
                 { href: "/sheet", label: "Practice Problems" },
@@ -115,19 +115,17 @@ export default function Footer() {
                       href={href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      whileHover={{ x: 4 }}
-                      className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-all duration-300 group text-sm"
+                      whileHover={{ x: 6 }}
+                      className="text-muted-foreground hover:text-blue-500 flex items-center gap-2 transition-all duration-300 text-sm"
                     >
-                      <span className="w-1.5 h-1.5 bg-muted-foreground group-hover:bg-blue-500 rounded-full transition-colors"></span>
                       {label}
                     </motion.a>
                   ) : (
-                    <motion.div whileHover={{ x: 4 }}>
+                    <motion.div whileHover={{ x: 6 }}>
                       <Link
                         href={href}
-                        className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-all duration-300 group text-sm"
+                        className="text-muted-foreground hover:text-blue-500 flex items-center gap-2 transition-all duration-300 text-sm"
                       >
-                        <span className="w-1.5 h-1.5 bg-muted-foreground group-hover:bg-blue-500 rounded-full transition-colors"></span>
                         {label}
                       </Link>
                     </motion.div>
@@ -148,7 +146,7 @@ export default function Footer() {
               <span className="bg-gradient-to-r from-blue-500 to-cyan-500 w-3 h-3 rounded-full"></span>
               Related Links
             </h3>
-            <ul className="space-y-3">
+            <ul className="space-y-3 list-none p-0 m-0">
               {[
                 { href: "/privacy-terms", label: "Privacy Policy" },
                 {
@@ -156,10 +154,7 @@ export default function Footer() {
                   external: true,
                   label: "Code of Conduct",
                 },
-                {
-                  href: "/privacy-terms?tab=terms",
-                  label: "Terms of Service",
-                },
+                { href: "/privacy-terms?tab=terms", label: "Terms of Service" },
                 {
                   href: "https://github.com/saumyayadav25/cpp-dsa-sheet-testing/blob/main/LICENSE",
                   external: true,
@@ -177,19 +172,17 @@ export default function Footer() {
                       href={href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      whileHover={{ x: 4 }}
-                      className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-all duration-300 group text-sm"
+                      whileHover={{ x: 6 }}
+                      className="text-muted-foreground hover:text-blue-500 flex items-center gap-2 transition-all duration-300 text-sm"
                     >
-                      <span className="w-1.5 h-1.5 bg-muted-foreground group-hover:bg-blue-500 rounded-full transition-colors"></span>
                       {label}
                     </motion.a>
                   ) : (
-                    <motion.div whileHover={{ x: 4 }}>
+                    <motion.div whileHover={{ x: 6 }}>
                       <Link
                         href={href}
-                        className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-all duration-300 group text-sm"
+                        className="text-muted-foreground hover:text-blue-500 flex items-center gap-2 transition-all duration-300 text-sm"
                       >
-                        <span className="w-1.5 h-1.5 bg-muted-foreground group-hover:bg-blue-500 rounded-full transition-colors"></span>
                         {label}
                       </Link>
                     </motion.div>


### PR DESCRIPTION
### Related Issue(s)
- Fixes #351 

### Summary
The footer currently displays links with bullet points, making the layout look cluttered and inconsistent with the modern design of the site.
This PR removes unnecessary list styling and enhances the footer UI with a cleaner look and improved hover effects.

### Changes
-  Removed default bullet points from footer link lists (list-none p-0 m-0).
-  Cleaned up extra decorative spans to make links simpler and more minimal.
-  Added consistent spacing (space-y-3) between links for readability.
-  Improved hover effects (color change + slight horizontal shift) for better interactivity.

### Screenshots (if applicable)
 **Before** 

<img width="1920" height="967" alt="Footer"  src="https://github.com/user-attachments/assets/275f2866-a2c1-45f1-81c8-244b859053d4" />

**After**

<img width="1920" height="900" alt="Fixed_FooterUI" src="https://github.com/user-attachments/assets/5ead5895-3307-4e66-8a96-edfd62143860" />
 

### Checklist
- [ ] I linked a related issue using `Fixes #<issue_number>`
- [ ] I tested locally and verified the changes work as expected
- [ ] I updated the docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
