### PR TITLE
feat: Made Question fetch in sorted order

### DIFF
--- a/app/api/questions/route.ts
+++ b/app/api/questions/route.ts
@@ -32,6 +32,8 @@ export async function GET(request: NextRequest) {
                     query.id = parseInt(topicId);
                 }
                 topics = await Topic.find(query).lean() as any;
+                // sort the data on basis of id to ensure consistent order
+                topics.sort((a, b) => a.id - b.id);
                 console.log("Topics found in database:", topics.length);
             } else {
                 console.log("No data in database, using sample data");

--- a/components/SheetContent.tsx
+++ b/components/SheetContent.tsx
@@ -105,6 +105,7 @@ export default function SheetContent({
           const contentType = response.headers.get('content-type') || '';
           if (contentType.includes('application/json')) {
             data = await response.json();
+           
           }
         } catch (parseErr) {
           console.warn('Failed to parse JSON from /api/questions response', parseErr);

--- a/db/config.ts
+++ b/db/config.ts
@@ -7,6 +7,7 @@ export const connect = async () => {
             return;
         }
 
+
         const mongoUri = process.env.MONGO_URI;
         if (!mongoUri) {
             console.log("MongoDB Connection failed - MONGO_URI environment variable is not set");


### PR DESCRIPTION

### Summary

The questions fetched from the database were being returned in an unsorted/shuffled order, which affected the consistency of the UI and user experience.
This PR updates the backend route to ensure that questions are **sorted by their `id` field** before being sent in the API response.

### Changes

* Updated the database query logic in the backend route.
* Applied sorting using `a.id - b.id` to return questions in ascending order.
* Ensured consistent order of questions across API responses.


### How to Test

1. Start the backend server.
2. Call the API endpoint for fetching questions.
3. Verify that the returned questions are sorted in ascending order by ID.

### Checklist

* [ ] I linked a related issue using `Fixes #<issue_number>`
* [ ] I tested locally and verified the changes work as expected
* [ ] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.

