### PR TITLE
Login page buttons UI changed

### DIFF
--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -192,10 +192,10 @@ export default function SigninPage() {
       <Button
         onClick={handleSubmit}
         disabled={loading}
-        className="w-full rounded-lg text-white bg-gradient-to-br from-blue-900 to-blue-500 transition-colors duration-300 hover:from-blue-600 hover:to-blue-800 relative z-10"
+        className="w-25 h-10 rounded-lg ml-35 text-white text-lg bg-gradient-to-br from-blue-900 to-blue-500 transition-colors duration-300 hover:from-blue-600 hover:to-blue-800 relative z-10 "
       >
         {loading ? (
-          <Loader2 className="animate-spin mr-2 h-4 w-4" />
+          <Loader2 className="animate-spin  mr-2 h-8 w-4" />
         ) : (
           "Sign In"
         )}
@@ -203,7 +203,7 @@ export default function SigninPage() {
 
       <div className="text-center font-bold text-blue-500 relative z-10">OR</div>
 
-      <div className="text-center relative z-10">
+      <div className="text-center relative z-10 ">
         <GoogleLoginButton />
       </div>
 

--- a/components/OAuthLogin.tsx
+++ b/components/OAuthLogin.tsx
@@ -19,16 +19,16 @@ export const GoogleLoginButton = () => {
     <div className="flex justify-center items-center gap-5">
       <Button
         onClick={handleGoogleLogin}
-        className="bg-white/80  text-white px-6 py-3 rounded-lg flex items-center justify-center transition-all duration-200 min-w-[160px] focus:outline-none focus:ring-2 focus:ring-blue-400"
+        className="bg-white/80  text-white px-6 py-3 rounded-full flex items-center justify-center transition-all duration-200 min-w-[50px] min-h-[50px] focus:outline-none focus:ring-2 focus:ring-blue-400 hover:bg-blue-300"
       >
-        <Image src={"/assets/google.png"} alt="Google" width={28} height={28} />
+        <Image src={"/assets/google.png"} alt="Google" width={30} height={30} />
       </Button>
-      <span className="mx-3 text-gray-400 font-semibold text-lg">|</span>
+      <span className="mx-3 text-gray-400 font-semibold text-2xl">|</span>
       <Button
         onClick={handleGithubLogin}
-        className="bg-white/80  text-white px-6 py-3 rounded-lg flex items-center justify-center transition-all duration-200 min-w-[160px] focus:outline-none focus:ring-2 focus:ring-blue-400"
+        className="bg-white/80  text-white px-6 py-3 rounded-full flex items-center justify-center transition-all duration-200 min-w-[50px] min-h-[50px] focus:outline-none focus:ring-2 focus:ring-blue-400 hover:bg-blue-300"
       >
-        <Image src={"/assets/github.png"} alt="Github" width={28} height={28} />
+        <Image src={"/assets/github.png"} alt="Github" width={30} height={30} />
       </Button>
     </div>
   );


### PR DESCRIPTION
### Related Issue(s)
- Fixes #377 

### Summary
This PR updates the login page UI by adjusting the width and styling of the Sign In, Google, and GitHub buttons. The buttons were previously too wide, creating a disproportionate layout compared to the input fields.

### Changes
- Reduced the width of Sign In, Google, and GitHub buttons for better alignment with input fields.
- Applied consistent border-radius for a modern and softer look.
- Enhanced overall UI balance and readability.

### Screenshots (if applicable)
<img width="1191" height="927" alt="Screenshot 2025-09-29 125435" src="https://github.com/user-attachments/assets/99f0f344-7c21-4a30-b936-c30862729361" />


### How to Test
1. checkout the added screenshot.

### Checklist
- [x] I linked a related issue using `Fixes #<issue_number>`
- [x] I tested locally and verified the changes work as expected
- [x] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
