### PR TITLE
Fix: Improve testimonial modal styling for light and dark mode compatibility

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -985,7 +985,7 @@ export default function Home() {
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.9, y: 20 }}
               transition={{ type: "spring", duration: 0.5 }}
-              className="relative backdrop-blur-2xl bg-gradient-to-br from-white/90 via-white/80 to-white/70 dark:from-gray-900/90 dark:via-gray-900/80 dark:to-blue-900/70 rounded-2xl p-8 max-w-2xl w-full max-h-[90vh] overflow-y-auto custom-scrollbar border border-white/20 dark:border-gray-700/30 shadow-2xl"
+               className="relative backdrop-blur-2xl bg-gradient-to-br from-white/90 via-white/80 to-white/70 dark:from-gray-900/90 dark:via-gray-900/80 dark:to-blue-900/70 rounded-2xl p-8 max-w-2xl w-full max-h-[90vh] overflow-y-auto custom-scrollbar border border-gray-200/30 dark:border-gray-700/30 shadow-2xl"
               onClick={(e) => e.stopPropagation()}
               style={{
                 scrollbarWidth: 'thin',
@@ -1004,26 +1004,26 @@ export default function Home() {
                 {/* Close button */}
                 <button
                   onClick={closeModal}
-                  className="absolute top-4 right-4 p-2 rounded-full hover:bg-gray-100/80 dark:hover:bg-gray-800/80 transition-colors backdrop-blur-sm z-20"
+                   className="absolute top-4 right-4 p-2 rounded-full hover:bg-gray-100/80 dark:hover:bg-gray-800/80 transition-colors backdrop-blur-sm z-20 text-gray-600 dark:text-gray-300"
                 >
                   <FiX size={20} />
                 </button>
 
                 {/* Form Header */}
                 <div className="text-center mb-8 pt-4">
-                  <h2 className="text-2xl font-bold text-white mb-2">
-                    Share Your Experience
-                  </h2>
-                  <p className="text-gray-300">
-                    Help others by sharing how DSAMate helped you in your journey
-                  </p>
+                   <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+                     Share Your Experience
+                   </h2>
+                   <p className="text-gray-600 dark:text-gray-300">
+                     Help others by sharing how DSAMate helped you in your journey
+                   </p>
                 </div>
 
                 {/* Form */}
                 <form onSubmit={handleSubmit} className="space-y-6">
                   {/* Name */}
                   <div>
-                    <label htmlFor="name" className="block text-sm font-medium text-gray-200 mb-2">
+                     <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                       Full Name *
                     </label>
                     <input
@@ -1033,14 +1033,14 @@ export default function Home() {
                       value={formData.name}
                       onChange={handleInputChange}
                       required
-                      className="w-full px-4 py-3 rounded-lg border border-gray-600/30 bg-gray-800/40 backdrop-blur-md text-gray-100 placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all"
+                       className="w-full px-4 py-3 rounded-lg border border-gray-300/50 dark:border-gray-600/30 bg-white/60 dark:bg-gray-800/40 backdrop-blur-md text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all"
                       placeholder="Enter your full name"
                     />
                   </div>
 
                   {/* Email */}
                   <div>
-                    <label htmlFor="email" className="block text-sm font-medium text-gray-200 mb-2">
+                     <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                       Email Address *
                     </label>
                     <input
@@ -1050,14 +1050,14 @@ export default function Home() {
                       value={formData.email}
                       onChange={handleInputChange}
                       required
-                      className="w-full px-4 py-3 rounded-lg border border-gray-600/30 bg-gray-800/40 backdrop-blur-md text-gray-100 placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all"
+                       className="w-full px-4 py-3 rounded-lg border border-gray-300/50 dark:border-gray-600/30 bg-white/60 dark:bg-gray-800/40 backdrop-blur-md text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all"
                       placeholder="Enter your email address"
                     />
                   </div>
 
                   {/* Designation */}
                   <div>
-                    <label htmlFor="designation" className="block text-sm font-medium text-gray-200 mb-2">
+                     <label htmlFor="designation" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                       Designation *
                     </label>
                     <input
@@ -1067,14 +1067,14 @@ export default function Home() {
                       value={formData.designation}
                       onChange={handleInputChange}
                       required
-                      className="w-full px-4 py-3 rounded-lg border border-gray-600/30 bg-gray-800/40 backdrop-blur-md text-gray-100 placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all"
+                       className="w-full px-4 py-3 rounded-lg border border-gray-300/50 dark:border-gray-600/30 bg-white/60 dark:bg-gray-800/40 backdrop-blur-md text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all"
                       placeholder="e.g., Student, Software Engineer, etc."
                     />
                   </div>
 
                   {/* Rating */}
                   <div>
-                    <label className="block text-sm font-medium text-gray-200 mb-3">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-3">
                       Overall Rating *
                     </label>
                     <div className="flex gap-2">
@@ -1088,7 +1088,7 @@ export default function Home() {
                           {star <= formData.rating ? (
                             <FaStar className="text-yellow-400" />
                           ) : (
-                            <FaRegStar className="text-gray-300 dark:text-gray-600" />
+                             <FaRegStar className="text-gray-400 dark:text-gray-600" />
                           )}
                         </button>
                       ))}
@@ -1097,7 +1097,7 @@ export default function Home() {
 
                   {/* What you liked most */}
                   <div>
-                    <label htmlFor="likedMost" className="block text-sm font-medium text-gray-200 mb-2">
+                     <label htmlFor="likedMost" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                       What did you like most about DSAMate? *
                     </label>
                     <textarea
@@ -1107,14 +1107,14 @@ export default function Home() {
                       onChange={handleInputChange}
                       required
                       rows={3}
-                      className="w-full px-4 py-3 rounded-lg border border-gray-600/30 bg-gray-800/40 backdrop-blur-md text-gray-100 placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all resize-vertical custom-scrollbar"
+                       className="w-full px-4 py-3 rounded-lg border border-gray-300/50 dark:border-gray-600/30 bg-white/60 dark:bg-gray-800/40 backdrop-blur-md text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all resize-vertical custom-scrollbar"
                       placeholder="Share what features or aspects you found most valuable..."
                     />
                   </div>
 
                   {/* How it helped */}
                   <div>
-                    <label htmlFor="howHelped" className="block text-sm font-medium text-gray-200 mb-2">
+                     <label htmlFor="howHelped" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                       How did DSAMate help you? *
                     </label>
                     <textarea
@@ -1124,14 +1124,14 @@ export default function Home() {
                       onChange={handleInputChange}
                       required
                       rows={3}
-                      className="w-full px-4 py-3 rounded-lg border border-gray-600/30 bg-gray-800/40 backdrop-blur-md text-gray-100 placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all resize-vertical custom-scrollbar"
+                       className="w-full px-4 py-3 rounded-lg border border-gray-300/50 dark:border-gray-600/30 bg-white/60 dark:bg-gray-800/40 backdrop-blur-md text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all resize-vertical custom-scrollbar"
                       placeholder="Share how DSAMate improved your learning journey..."
                     />
                   </div>
 
                   {/* Feedback */}
                   <div>
-                    <label htmlFor="feedback" className="block text-sm font-medium text-gray-200 mb-2">
+                     <label htmlFor="feedback" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                       Additional Feedback *
                     </label>
                     <textarea
@@ -1141,7 +1141,7 @@ export default function Home() {
                       onChange={handleInputChange}
                       required
                       rows={4}
-                      className="w-full px-4 py-3 rounded-lg border border-gray-600/30 bg-gray-800/40 backdrop-blur-md text-gray-100 placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all resize-vertical custom-scrollbar"
+                       className="w-full px-4 py-3 rounded-lg border border-gray-300/50 dark:border-gray-600/30 bg-white/60 dark:bg-gray-800/40 backdrop-blur-md text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400/50 transition-all resize-vertical custom-scrollbar"
                       placeholder="Any additional thoughts, suggestions, or experiences you'd like to share..."
                     />
                   </div>
@@ -1154,9 +1154,9 @@ export default function Home() {
                       name="canShow"
                       checked={formData.canShow}
                       onChange={handleInputChange}
-                      className="w-4 h-4 text-blue-400 bg-gray-800/60 border-gray-600/50 rounded focus:ring-blue-400 focus:ring-2 backdrop-blur-sm"
+                      className="w-4 h-4 text-blue-400 bg-transparent border-gray-300/50 dark:border-gray-600/50 rounded focus:outline-none"
                     />
-                    <label htmlFor="canShow" className="text-sm text-gray-200">
+                     <label htmlFor="canShow" className="text-sm text-gray-700 dark:text-gray-200">
                       I allow DSAMate to display this testimonial publicly
                     </label>
                   </div>
@@ -1164,7 +1164,7 @@ export default function Home() {
                   {/* Display Preference - Only show if canShow is true */}
                   {formData.canShow && (
                     <div>
-                      <label className="block text-sm font-medium text-gray-200 mb-3">
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-3">
                         If yes, how would you like your feedback to be shown? *
                       </label>
                       <div className="space-y-3">
@@ -1176,9 +1176,9 @@ export default function Home() {
                             value="nameAndDesignation"
                             checked={formData.displayPreference === "nameAndDesignation"}
                             onChange={handleInputChange}
-                            className="w-4 h-4 text-blue-400 bg-gray-800/60 border-gray-600/50 focus:ring-blue-400 focus:ring-2 backdrop-blur-sm"
+                            className="w-4 h-4 text-blue-400 bg-transparent border-gray-300/50 dark:border-gray-600/50 focus:outline-none"
                           />
-                          <label htmlFor="nameAndDesignation" className="ml-2 text-sm text-gray-200">
+                           <label htmlFor="nameAndDesignation" className="ml-2 text-sm text-gray-700 dark:text-gray-200">
                             Use my name and designation
                           </label>
                         </div>
@@ -1190,9 +1190,9 @@ export default function Home() {
                             value="nameOnly"
                             checked={formData.displayPreference === "nameOnly"}
                             onChange={handleInputChange}
-                            className="w-4 h-4 text-blue-400 bg-gray-800/60 border-gray-600/50 focus:ring-blue-400 focus:ring-2 backdrop-blur-sm"
+                            className="w-4 h-4 text-blue-400 bg-transparent border-gray-300/50 dark:border-gray-600/50 focus:outline-none"
                           />
-                          <label htmlFor="nameOnly" className="ml-2 text-sm text-gray-200">
+                           <label htmlFor="nameOnly" className="ml-2 text-sm text-gray-700 dark:text-gray-200">
                             Use my name only
                           </label>
                         </div>
@@ -1204,9 +1204,9 @@ export default function Home() {
                             value="anonymous"
                             checked={formData.displayPreference === "anonymous"}
                             onChange={handleInputChange}
-                            className="w-4 h-4 text-blue-400 bg-gray-800/60 border-gray-600/50 focus:ring-blue-400 focus:ring-2 backdrop-blur-sm"
+                            className="w-4 h-4 text-blue-400 bg-transparent border-gray-300/50 dark:border-gray-600/50 focus:outline-none"
                           />
-                          <label htmlFor="anonymous" className="ml-2 text-sm text-gray-200">
+                           <label htmlFor="anonymous" className="ml-2 text-sm text-gray-700 dark:text-gray-200">
                             As anonymous user
                           </label>
                         </div>
@@ -1219,7 +1219,7 @@ export default function Home() {
                     <button
                       type="button"
                       onClick={closeModal}
-                      className="flex-1 px-6 py-3 border border-gray-600/50 bg-gray-800/40 backdrop-blur-md text-gray-200 rounded-lg hover:bg-gray-700/60 transition-all font-medium"
+                       className="flex-1 px-6 py-3 border border-gray-300/50 dark:border-gray-600/50 bg-white/60 dark:bg-gray-800/40 backdrop-blur-md text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-100/80 dark:hover:bg-gray-700/60 transition-all font-medium"
                     >
                       Cancel
                     </button>


### PR DESCRIPTION
### Related Issue(s)
- Fixes #385 

### Summary
Fixed testimonial modal styling to work properly in both light and dark modes.

### Changes
- Fixed testimonial modal styling to work properly in both light and dark modes. The modal was previously using hardcoded dark mode colors throughout, making it difficult to read and use in light mode. This PR implements responsive styling that adapts to both themes while maintaining the glassmorphism design aesthetic.

### Screenshots (if applicable)
<img width="1740" height="2147" alt="image" src="https://github.com/user-attachments/assets/d2ec53aa-2c2a-4f64-9429-6f32d1efc6d6" />

### How to Test

1. Open the application in light mode and click "Give a Testimonial" button
2. Verify all form elements (labels, inputs, textareas, buttons) are clearly visible and readable
3. Switch to dark mode and confirm the modal maintains proper contrast and readability
4. Test form interactions (typing, selecting radio buttons, checking checkbox) in both modes
5. Verify the modal closes properly and form submission works as expected
6. 

### Checklist
- [X] I linked a related issue using `Fixes #<issue_number>`
- [ ] I am GSSoC'25 contributor
- [X] I am Hacktoberfest'25 contributor
- [X] I tested locally and verified the changes work as expected
- [ ] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
