### PR TITLE
Added new Flashcards

### DIFF
--- a/components/mode-toggle.tsx
+++ b/components/mode-toggle.tsx
@@ -19,6 +19,15 @@ export function ModeToggle() {
 
   const effectiveTheme = theme === "system" ? systemTheme : theme
 
+  const [mounted, setMounted]=React.useState(false);
+React.useEffect(()=>{
+  setMounted(true);
+}, []);
+
+if(!mounted){
+  return null;
+}
+
   return (
     <Button
       variant="outline"

--- a/components/ui/conceptCard.tsx
+++ b/components/ui/conceptCard.tsx
@@ -85,8 +85,9 @@ const ConceptCard: React.FC<ConceptCardProps> = ({
           <p className="text-sm">{topic?.length} Topics</p>
         </div>
         <div className="flex justify-start space-x-2 mt-4">
-          {topic?.map((tag) => (
-            <Badge variant="default">{tag}</Badge>
+          {topic?.map((tag,idx) => (
+            <Badge key={tag} 
+            variant="default">{tag}</Badge>
           ))}
         </div>
         <button className="flex items-center mt-2 justify-center space-x-2 relative py-2 bg-gradient-to-br from-blue-600/10 to-blue-500/5 rounded-lg text-blue-600 group dark:text-blue-400 border border-blue-600/10 dark:border-blue-600/20">

--- a/data/flashcards.ts
+++ b/data/flashcards.ts
@@ -93,21 +93,21 @@ export const flashcards: Flashcard[] = [
     id: 12,
     term: "Bubble Sort",
     explanation: "Bubble sort repeatedly steps through the list, compares adjacent elements, and swaps them if they are in the wrong order, pushing larger elements to the end. It's simple but inefficient with O(n²) time complexity.",
-    difficulty: "Intermediate",
+    difficulty: "Basic",
     category: "Sorting"
   },
   {
     id: 13,
     term: "Selection Sort",
     explanation: "Selection sort repeatedly finds the smallest element from the unsorted part and swaps it with the first unsorted element, building a sorted list from left to right.",
-    difficulty: "Intermediate",
+    difficulty: "Basic",
     category: "Sorting"
   },
    {
     id: 14,
-    term: "Insetion Sort",
+    term: "Insertion Sort",
     explanation: "Insertion Sort builds the sorted list one element at a time by inserting each new element into its correct position among the already sorted ones.",
-    difficulty: "Intermediate",
+    difficulty: "Basic",
     category: "Sorting"
   },
   
@@ -134,28 +134,271 @@ export const flashcards: Flashcard[] = [
     difficulty: "Intermediate",
     category: "Data Structures"
   },
-
-  // Recursion
   {
     id: 18,
+    term: "Linked List",
+    explanation: "A linked list is a linear data structure where elements (nodes) are connected using pointers, with each node containing data and a reference to the next (and sometimes previous) node.",
+    difficulty: "Basic",
+    category: "Data Structures"
+  },
+  {
+    id: 19,
+    term: "Stack",
+    explanation: "A stack is a linear data structure that follows the LIFO (Last In, First Out) principle, where insertion and deletion happen only at the top.",
+    difficulty: "Basic",
+    category: "Data Structures"
+  },
+  {
+    id: 20,
+    term: "Queue",
+    explanation: "A queue is a linear data structure that follows the FIFO (First In, First Out) principle, where elements are added at the rear and removed from the front.",
+    difficulty: "Basic",
+    category: "Data Structures"
+  },
+  
+  // Recursion
+  {
+    id: 21,
     term: "Recursion",
     explanation: "Problem-solving technique where function calls itself with smaller subproblems. Requires base case and recursive case. Can lead to stack overflow if not properly bounded.",
     difficulty: "Basic",
     category: "Recursion"
   },
   {
-    id: 19,
+    id: 22,
     term: "Dynamic Programming",
     explanation: "Optimization technique that solves complex problems by breaking them into simpler subproblems and storing results. Avoids redundant calculations. Two approaches: memoization (top-down) and tabulation (bottom-up).",
     difficulty: "Intermediate",
     category: "Recursion"
   },
   {
-    id: 20,
+    id: 23,
     term: "Backtracking",
     explanation: "Algorithmic approach that considers searching every possible combination to solve computational problems. Builds solution incrementally and abandons candidates that cannot lead to valid solution.",
     difficulty: "Intermediate",
     category: "Recursion"
+  },
+  {
+    id: 24,
+    term: "Tail Recursion",
+    explanation: "Tail recursion is a type of recursion where the recursive call is the last operation in the function, allowing some compilers to optimize and reuse stack frames.",
+    difficulty: "Intermediate",
+    category: "Recursion"
+  },
+  {
+    id: 25,
+    term: "Base Condition",
+    explanation: "A base condition is the stopping criterion in a recursive function that prevents infinite recursion by providing a direct answer for simple cases.",
+    difficulty: "Basic",
+    category: "Recursion"
+  },
+
+  //Trees
+
+  {
+    id: 26,
+    term: "Binary Trees",
+    explanation: "A tree where each node has at most two children, commonly called left and right.",
+    difficulty: "Basic",
+    category: "Trees"
+  },
+
+  {
+    id: 27,
+    term: "AVL Trees",
+    explanation: "A self-balancing binary search tree where the height difference between left and right subtrees of any node is at most 1.",
+    difficulty: "Basic",
+    category: "Trees"
+  },
+
+  {
+    id: 28,
+    term: "Red-Black Trees",
+    explanation: "Self-balancing BST where each node has a color (red or black) and specific rules ensure balanced height for efficient operations.",
+    difficulty: "Basic",
+    category: "Trees"
+  },
+
+  {
+    id: 29,
+    term: "Segment Trees",
+    explanation: "A tree used for range queries and updates on arrays, storing aggregate information (like sum or min) in each node.",
+    difficulty: "Basic",
+    category: "Trees"
+  },
+
+  {
+    id: 30,
+    term: "Trie (Prefix Tree)",
+    explanation: "A tree-like structure used to store strings, where each node represents a character, enabling fast prefix-based searches.",
+    difficulty: "Intermediate",
+    category: "Trees"
+  },
+
+  //Algorithms (Graphs)
+
+  {
+    id: 31,
+    term: "Dijkstra's Algorithm",
+    explanation: "An algorithm to find the shortest path from a source vertex to all other vertices in a weighted graph with non-negative edges.",
+    difficulty: "Intermediate",
+    category: "Algorithms"
+  },
+
+  {
+    id: 32,
+    term: "Bellman-Ford Algorithm",
+    explanation: "An algorithm to find shortest paths from a source vertex in a weighted graph, capable of handling negative weights.",
+    difficulty: "Intermediate",
+    category: "Algorithms"
+  },
+
+  {
+    id: 33,
+    term: "Floyd-Warshall Algorithm",
+    explanation: "An algorithm to find shortest paths between all pairs of vertices in a weighted graph.",
+    difficulty: "Intermediate",
+    category: "Algorithms"
+  },
+
+   {
+    id: 34,
+    term: "Kruskal's Algorithm",
+    explanation: "A greedy algorithm to find a minimum spanning tree of a connected, weighted graph by choosing edges in increasing order of weight.",
+    difficulty: "Intermediate",
+    category: "Algorithms"
+  },
+
+ {
+    id: 35,
+    term: "Prim's Algorithm",
+    explanation: "A greedy algorithm to find a minimum spanning tree by starting from a vertex and repeatedly adding the smallest edge connecting the tree to a new vertex.",
+    difficulty: "Intermediate",
+    category: "Algorithms"
+  },
+
+  {
+    id: 36,
+    term: "Bit Manipulation",
+    explanation: "Techniques to perform operations on integers at the binary level using AND, OR, XOR, shifts, etc.",
+    difficulty: "Intermediate",
+    category: "Algorithms"
+  },
+
+//Advanced Data Structure
+
+ {
+    id: 37,
+    term: "Fenwick Tree (Binary Indexed Tree)",
+    explanation: "A data structure that efficiently supports prefix sum queries and updates in logarithmic time.",
+    difficulty: "Intermediate",
+    category: "Advanced Data Structure"
+  },
+ 
+  {
+    id: 38,
+    term: "Union-Find (Disjoint Set)",
+    explanation: "A data structure to keep track of disjoint sets and efficiently perform union and find operations.",
+    difficulty: "Intermediate",
+    category: "Advanced Data Structure"
+  },
+
+   {
+    id: 39,
+    term: "Skip List",
+    explanation: "A layered linked list with multiple levels that allows fast search, insertion, and deletion in O(log n) expected time.",
+    difficulty: "Intermediate",
+    category: "Advanced Data Structure"
+  },
+
+  {
+    id: 40,
+    term: "Suffix Tree",
+    explanation: "A compressed trie containing all the suffixes of a given string, used for fast pattern matching and string queries.",
+    difficulty: "Intermediate",
+    category: "Advanced Data Structure"
+  },
+
+  //Miscellaneous
+
+  {
+    id: 41,
+    term: "Kadane's Algorithm",
+    explanation: "An efficient method to find the maximum sum subarray in a 1D array using dynamic programming principles.",
+    difficulty: "Basic",
+    category: "Miscellaneous"
+  },
+
+    {
+    id: 42,
+    term: "Mo's Algorithm",
+    explanation: "A technique to answer offline range queries on arrays efficiently by sorting queries and using a sliding window approach.",
+    difficulty: "Intermediate",
+    category: "Miscellaneous"
+  },
+
+    {
+    id: 43,
+    term: "Sliding Window Technique",
+    explanation: "A method to solve array/string problems by maintaining a window of elements and moving it across the data.",
+    difficulty: "Intermediate",
+    category: "Miscellaneous"
+  },
+
+    {
+    id: 44,
+    term: "Two Pointers Technique",
+    explanation: "An approach using two indices to traverse an array or string simultaneously to solve problems efficiently.",
+    difficulty: "Intermediate",
+    category: "Miscellaneous"
+  },
+
+    {
+    id: 45,
+    term: "Huffman Encoding",
+    explanation: "A greedy algorithm for compressing data by building a binary tree based on character frequencies to minimize encoding length.",
+    difficulty: "Intermediate",
+    category: "Miscellaneous"
+  },
+
+   {
+    id: 46,
+    term: "Articulation Point",
+    explanation: "A vertex in a graph whose removal increases the number of connected components.",
+    difficulty: "Intermediate",
+    category: "Miscellaneous"
+  },
+
+   {
+    id: 47,
+    term: "Kosaraju's Algorithm",
+    explanation: "An algorithm to find strongly connected components in a directed graph using two DFS passes.",
+    difficulty: "Intermediate",
+    "category": "Miscellaneous"
+  },
+
+   {
+     id: 48,
+    term: "Tarjan's Algorithm",
+    explanation: "A DFS-based algorithm to find strongly connected components or articulation points in a graph efficiently.",
+    difficulty: "Intermediate",
+    category: "Miscellaneous"
+  },
+
+   {
+    id: 49,
+    term: "Suffix Array",
+    explanation: "An array of all sorted suffixes of a string, used for efficient pattern searching and string processing.",
+    difficulty: "Intermediate",
+    category: "Miscellaneous"
+  },
+
+   {
+     id: 50,
+    term: "Priority Queue",
+    explanation: "A queue where each element has a priority, and elements with higher priority are served before lower priority ones.",
+    difficulty: "Basic",
+    category: "Miscellaneous"
   }
 ];
 
@@ -165,7 +408,11 @@ export const categories = [
   "Graph Traversals",
   "Sorting",
   "Data Structures",
-  "Recursion"
+  "Recursion",
+  "Trees",
+  "Algorithms",
+  "Advanced Data Structure",
+  "Miscellaneous"
 ] as const;
 
 export const difficulties = ["All", "Basic", "Intermediate"] as const;

--- a/data/flashcards.ts
+++ b/data/flashcards.ts
@@ -89,24 +89,46 @@ export const flashcards: Flashcard[] = [
     difficulty: "Intermediate",
     category: "Sorting"
   },
+  {
+    id: 12,
+    term: "Bubble Sort",
+    explanation: "Bubble sort repeatedly steps through the list, compares adjacent elements, and swaps them if they are in the wrong order, pushing larger elements to the end. It's simple but inefficient with O(n²) time complexity.",
+    difficulty: "Intermediate",
+    category: "Sorting"
+  },
+  {
+    id: 13,
+    term: "Selection Sort",
+    explanation: "Selection sort repeatedly finds the smallest element from the unsorted part and swaps it with the first unsorted element, building a sorted list from left to right.",
+    difficulty: "Intermediate",
+    category: "Sorting"
+  },
+   {
+    id: 14,
+    term: "Insetion Sort",
+    explanation: "Insertion Sort builds the sorted list one element at a time by inserting each new element into its correct position among the already sorted ones.",
+    difficulty: "Intermediate",
+    category: "Sorting"
+  },
+  
 
   // Data Structures
   {
-    id: 12,
+    id: 15,
     term: "Hash Table",
     explanation: "Data structure that maps keys to values using hash function. Average O(1) for search, insert, delete. Handles collisions via chaining or open addressing.",
     difficulty: "Basic",
     category: "Data Structures"
   },
   {
-    id: 13,
+    id: 16,
     term: "Binary Search Tree (BST)",
     explanation: "Binary tree where left subtree contains nodes with keys less than parent, right subtree contains greater keys. Average O(log n) operations, worst O(n) if unbalanced.",
     difficulty: "Intermediate",
     category: "Data Structures"
   },
   {
-    id: 14,
+    id: 17,
     term: "Heap",
     explanation: "Complete binary tree satisfying heap property. Max-heap: parent ≥ children, Min-heap: parent ≤ children. Used in priority queues, heap sort. Insert/delete: O(log n).",
     difficulty: "Intermediate",
@@ -115,21 +137,21 @@ export const flashcards: Flashcard[] = [
 
   // Recursion
   {
-    id: 15,
+    id: 18,
     term: "Recursion",
     explanation: "Problem-solving technique where function calls itself with smaller subproblems. Requires base case and recursive case. Can lead to stack overflow if not properly bounded.",
     difficulty: "Basic",
     category: "Recursion"
   },
   {
-    id: 16,
+    id: 19,
     term: "Dynamic Programming",
     explanation: "Optimization technique that solves complex problems by breaking them into simpler subproblems and storing results. Avoids redundant calculations. Two approaches: memoization (top-down) and tabulation (bottom-up).",
     difficulty: "Intermediate",
     category: "Recursion"
   },
   {
-    id: 17,
+    id: 20,
     term: "Backtracking",
     explanation: "Algorithmic approach that considers searching every possible combination to solve computational problems. Builds solution incrementally and abandons candidates that cannot lead to valid solution.",
     difficulty: "Intermediate",


### PR DESCRIPTION
### Related Issue(s)
- Fixes #315 

### Summary
Problem was to add new flashcards.

### Changes
- Earlier there were only 17 flashcards
- Added 33 more. Total 50 flashcards available on different topics.
- 

### Screenshots (if applicable)
<!-- Drag & drop images or paste links -->
<img width="1920" height="1080" alt="Screenshot (382)" src="https://github.com/user-attachments/assets/34a111d6-8cee-4d5c-9ebb-85f1c01425f3" />


### How to Test
1. Run the project locally
2. Go to theory cheatsheets and flashcards section in learning tools
3. View the flashcards
4. 

### Checklist
- [ x] I linked a related issue using `Fixes #315 
- [ x] I am GSSoC'25 contributor
- [x ] I am Hacktoberfest'25 contributor
- [x ] I tested locally and verified the changes work as expected
- [x ] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
