### PR TITLE
[FEAT]: Sync POTD and Mark as Done

### DIFF
--- a/components/POTD.tsx
+++ b/components/POTD.tsx
@@ -3,7 +3,7 @@
 /*
  * POTD (Problem of the Day) Component with One-Way Sync to DSA Sheet
  * 
- * ✅ ACCEPTANCE CRITERIA IMPLEMENTED:
+ *  ACCEPTANCE CRITERIA IMPLEMENTED:
  * 
  * 1. Marking POTD as done also checks the corresponding DSA list question.
  *    - When user marks POTD as done, findQuestionInDSASheet() locates the matching question
@@ -116,13 +116,13 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
         }
       }));
 
-      console.log(`✅ Updated DSA sheet progress for ${progressKey} (${questionTitle})`);
+      console.log(` Updated DSA sheet progress for ${progressKey} (${questionTitle})`);
     } catch (error) {
       console.error("❌ Error updating DSA sheet progress:", error);
     }
   };
 
-  // ✅ Check if user is logged in
+  //  Check if user is logged in
   useEffect(() => {
     const checkAuth = async () => {
       try {
@@ -145,7 +145,7 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
     checkAuth();
   }, []);
 
-  // ✅ Check if today's POTD is already done (independent of DSA sheet progress)
+  //  Check if today's POTD is already done (independent of DSA sheet progress)
   useEffect(() => {
     const currentDate = new Date().toDateString();
     setToday(currentDate);
@@ -162,7 +162,7 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
     });
   }, [potd]);
 
-  // ✅ Mark POTD as done and update backend progress + ONE-WAY sync with DSA sheet
+  //  Mark POTD as done and update backend progress + ONE-WAY sync with DSA sheet
   const handleMarkDone = async () => {
     if (!user) {
       setShowLoginModal(true);
@@ -178,19 +178,19 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
       });
 
       if (res.status === 200) {
-        console.log("✅ Backend progress updated:", res.data);
+        console.log(" Backend progress updated:", res.data);
 
         // Mark POTD as done for today (date-based, not question-based)
         localStorage.setItem("potd_last_done", today);
         setIsSolved(true);
 
-        // ✅ ACCEPTANCE CRITERIA #1: ONE-WAY SYNC to DSA sheet
+        //  ACCEPTANCE CRITERIA #1: ONE-WAY SYNC to DSA sheet
         // When POTD is marked as done, also mark the corresponding DSA list question as done
         if (potd) {
           const dsaQuestionInfo = findQuestionInDSASheet(potd);
           if (dsaQuestionInfo) {
             updateDSASheetProgress(dsaQuestionInfo.progressKey, potd.title);
-            console.log(`✅ Synced POTD completion to DSA sheet: Topic ${dsaQuestionInfo.topicId}, Question ${dsaQuestionInfo.questionId} (${dsaQuestionInfo.topicName})`);
+            console.log(` Synced POTD completion to DSA sheet: Topic ${dsaQuestionInfo.topicId}, Question ${dsaQuestionInfo.questionId} (${dsaQuestionInfo.topicName})`);
           } else {
             console.warn("⚠️ Could not find corresponding DSA sheet question for POTD:", potd.title);
           }
@@ -309,7 +309,7 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
           </Button>
         ) : (
           <div className="text-green-600 dark:text-green-400 font-medium text-sm bg-green-50 dark:bg-green-900/20 px-3 py-2 rounded-md border border-green-200 dark:border-green-900/40 flex items-center gap-2">
-            <span>✅</span>
+            <span></span>
             <span>Today's POTD Completed!</span>
           </div>
         )}

--- a/components/POTD.tsx
+++ b/components/POTD.tsx
@@ -1,7 +1,30 @@
 "use client";
 
+/*
+ * POTD (Problem of the Day) Component with One-Way Sync to DSA Sheet
+ * 
+ * ✅ ACCEPTANCE CRITERIA IMPLEMENTED:
+ * 
+ * 1. Marking POTD as done also checks the corresponding DSA list question.
+ *    - When user marks POTD as done, findQuestionInDSASheet() locates the matching question
+ *    - updateDSASheetProgress() marks it as solved in localStorage
+ *    - Real-time sync via custom events to update SheetContent component
+ * 
+ * 2. Repeated POTD questions appear unchecked in POTD, even if marked in DSA sheet as done.
+ *    - POTD status is date-based (potd_last_done) not question-based
+ *    - Same question can appear on different days and will show as unchecked each time
+ * 
+ * 3. Marking a DSA list question does not affect POTD.
+ *    - No reverse sync implemented - this component only sends, never receives DSA status
+ *    - POTD status is completely independent of DSA sheet progress
+ * 
+ * 4. Changes persist properly and can be tested locally.
+ *    - All progress saved to localStorage with proper event dispatch
+ *    - SheetContent component listens for changes and updates in real-time
+ */
+
 import { useState, useEffect } from "react";
-import { Question } from "@/data/questions";
+import { Question, sampleTopics } from "@/data/questions";
 import axios from "axios";
 import { useRouter } from "next/navigation";
 import {
@@ -34,6 +57,71 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
   const [showLoginModal, setShowLoginModal] = useState(false);
   const router = useRouter();
 
+  // Function to find the topic and question IDs for the POTD question
+  const findQuestionInDSASheet = (potdQuestion: Question) => {
+    for (const topic of sampleTopics) {
+      const foundQuestion = topic.questions.find(
+        (q) => q.id === potdQuestion.id && q.title.trim() === potdQuestion.title.trim()
+      );
+      if (foundQuestion) {
+        return {
+          topicId: topic.id,
+          questionId: foundQuestion.id,
+          progressKey: `${topic.id}-${foundQuestion.id}`,
+          topicName: topic.name
+        };
+      }
+    }
+
+    // Fallback: try to find by title only if ID matching fails
+    for (const topic of sampleTopics) {
+      const foundQuestion = topic.questions.find(
+        (q) => q.title.trim().toLowerCase() === potdQuestion.title.trim().toLowerCase()
+      );
+      if (foundQuestion) {
+        console.log(`Found question by title fallback: ${foundQuestion.title} in topic ${topic.name}`);
+        return {
+          topicId: topic.id,
+          questionId: foundQuestion.id,
+          progressKey: `${topic.id}-${foundQuestion.id}`,
+          topicName: topic.name
+        };
+      }
+    }
+
+    return null;
+  };
+
+  // Function to update DSA sheet progress in localStorage
+  const updateDSASheetProgress = (progressKey: string, questionTitle: string) => {
+    try {
+      const currentProgress = JSON.parse(localStorage.getItem("dsa-progress") || "{}");
+      const updatedProgress = {
+        ...currentProgress,
+        [progressKey]: {
+          ...currentProgress[progressKey],
+          isSolved: true,
+          solvedAt: new Date().toISOString(),
+          // Add source info for debugging
+          solvedVia: 'POTD'
+        }
+      };
+      localStorage.setItem("dsa-progress", JSON.stringify(updatedProgress));
+
+      // Dispatch custom event to notify other components of the localStorage change
+      window.dispatchEvent(new CustomEvent("localStorageChange", {
+        detail: {
+          key: "dsa-progress",
+          newValue: JSON.stringify(updatedProgress)
+        }
+      }));
+
+      console.log(`✅ Updated DSA sheet progress for ${progressKey} (${questionTitle})`);
+    } catch (error) {
+      console.error("❌ Error updating DSA sheet progress:", error);
+    }
+  };
+
   // ✅ Check if user is logged in
   useEffect(() => {
     const checkAuth = async () => {
@@ -57,15 +145,24 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
     checkAuth();
   }, []);
 
-  // ✅ Check if today's POTD is already done
+  // ✅ Check if today's POTD is already done (independent of DSA sheet progress)
   useEffect(() => {
     const currentDate = new Date().toDateString();
     setToday(currentDate);
+
+    // IMPORTANT: POTD status is date-based, NOT question-based
+    // This ensures repeated questions appear unchecked in POTD
     const lastDone = localStorage.getItem("potd_last_done");
     setIsSolved(currentDate === lastDone);
-  }, []);
 
-  // ✅ Mark POTD as done and update backend progress
+    console.log(`📅 POTD status check for ${currentDate}:`, {
+      lastDone,
+      isSolved: currentDate === lastDone,
+      potdTitle: potd?.title
+    });
+  }, [potd]);
+
+  // ✅ Mark POTD as done and update backend progress + ONE-WAY sync with DSA sheet
   const handleMarkDone = async () => {
     if (!user) {
       setShowLoginModal(true);
@@ -73,6 +170,7 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
     }
 
     try {
+      // Update backend progress (existing functionality)
       const res = await axios.post("/api/progress/update", {
         userId: user._id, // Required by backend
         questionDifficulty: potd?.difficulty || "medium", // Use actual difficulty
@@ -80,13 +178,25 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
       });
 
       if (res.status === 200) {
-        console.log("Progress updated:", res.data);
+        console.log("✅ Backend progress updated:", res.data);
 
-        // Mark locally to avoid multiple submissions in same day
+        // Mark POTD as done for today (date-based, not question-based)
         localStorage.setItem("potd_last_done", today);
         setIsSolved(true);
 
-        // Optionally update streak UI if needed
+        // ✅ ACCEPTANCE CRITERIA #1: ONE-WAY SYNC to DSA sheet
+        // When POTD is marked as done, also mark the corresponding DSA list question as done
+        if (potd) {
+          const dsaQuestionInfo = findQuestionInDSASheet(potd);
+          if (dsaQuestionInfo) {
+            updateDSASheetProgress(dsaQuestionInfo.progressKey, potd.title);
+            console.log(`✅ Synced POTD completion to DSA sheet: Topic ${dsaQuestionInfo.topicId}, Question ${dsaQuestionInfo.questionId} (${dsaQuestionInfo.topicName})`);
+          } else {
+            console.warn("⚠️ Could not find corresponding DSA sheet question for POTD:", potd.title);
+          }
+        }
+
+        // Update streak UI
         updateStreak();
 
         // Play success sound
@@ -117,13 +227,12 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
           <p className="text-sm mt-2 text-muted-foreground capitalize">
             Difficulty:{" "}
             <span
-              className={`font-semibold ${
-                potd.difficulty === "easy"
-                  ? "text-green-600 dark:text-green-400"
-                  : potd.difficulty === "medium"
+              className={`font-semibold ${potd.difficulty === "easy"
+                ? "text-green-600 dark:text-green-400"
+                : potd.difficulty === "medium"
                   ? "text-yellow-600 dark:text-yellow-400"
                   : "text-red-600 dark:text-red-400"
-              }`}
+                }`}
             >
               {potd.difficulty}
             </span>
@@ -135,35 +244,35 @@ export default function POTD({ potd, updateStreak }: POTDProps) {
                 platform === "leetcode"
                   ? "LeetCode"
                   : platform === "gfg"
-                  ? "GeeksForGeeks"
-                  : platform === "hackerrank"
-                  ? "HackerRank"
-                  : platform === "spoj"
-                  ? "SPOJ"
-                  : platform === "ninja"
-                  ? "Coding Ninjas"
-                  : platform === "code"
-                  ? "Other Platform"
-                  : platform === "custom"
-                  ? "View Question"
-                  : platform;
+                    ? "GeeksForGeeks"
+                    : platform === "hackerrank"
+                      ? "HackerRank"
+                      : platform === "spoj"
+                        ? "SPOJ"
+                        : platform === "ninja"
+                          ? "Coding Ninjas"
+                          : platform === "code"
+                            ? "Other Platform"
+                            : platform === "custom"
+                              ? "View Question"
+                              : platform;
 
               const textColor =
                 platform === "leetcode"
                   ? "text-blue-600 dark:text-blue-400"
                   : platform === "gfg"
-                  ? "text-green-600 dark:text-green-400"
-                  : platform === "hackerrank"
-                  ? "text-yellow-600 dark:text-yellow-300"
-                  : platform === "spoj"
-                  ? "text-purple-600 dark:text-purple-400"
-                  : platform === "ninja"
-                  ? "text-pink-600 dark:text-pink-400"
-                  : platform === "code"
-                  ? "text-orange-600 dark:text-orange-400"
-                  : platform === "custom"
-                  ? "text-blue-600 dark:text-blue-300"
-                  : "text-muted-foreground";
+                    ? "text-green-600 dark:text-green-400"
+                    : platform === "hackerrank"
+                      ? "text-yellow-600 dark:text-yellow-300"
+                      : platform === "spoj"
+                        ? "text-purple-600 dark:text-purple-400"
+                        : platform === "ninja"
+                          ? "text-pink-600 dark:text-pink-400"
+                          : platform === "code"
+                            ? "text-orange-600 dark:text-orange-400"
+                            : platform === "custom"
+                              ? "text-blue-600 dark:text-blue-300"
+                              : "text-muted-foreground";
 
               return (
                 <a

--- a/components/SheetContent.tsx
+++ b/components/SheetContent.tsx
@@ -202,14 +202,14 @@ export default function SheetContent({
   }, []);
 
   // Listen for localStorage changes from other components (like POTD)
-  // ✅ ACCEPTANCE CRITERIA: This enables one-way sync from POTD to DSA sheet
+  //  ACCEPTANCE CRITERIA: This enables one-way sync from POTD to DSA sheet
   useEffect(() => {
     const handleStorageChange = (e: StorageEvent) => {
       if (e.key === "dsa-progress" && e.newValue) {
         try {
           const newProgress = JSON.parse(e.newValue);
           setProgress(newProgress);
-          console.log("✅ Updated progress from storage event (cross-tab):", newProgress);
+          console.log(" Updated progress from storage event (cross-tab):", newProgress);
         } catch (error) {
           console.error("Error parsing updated progress from storage:", error);
         }
@@ -226,7 +226,7 @@ export default function SheetContent({
         try {
           const newProgress = JSON.parse(customEvent.detail.newValue);
           setProgress(newProgress);
-          console.log("✅ Updated progress from POTD sync:", newProgress);
+          console.log(" Updated progress from POTD sync:", newProgress);
         } catch (error) {
           console.error("Error parsing updated progress from custom storage:", error);
         }
@@ -327,9 +327,9 @@ export default function SheetContent({
     }
 
     const currentFieldValue = !!(progress[id]?.[field]);
-    console.log("✅ DSA sheet question toggling:", { id, field, questionDifficulty, topicName });
+    console.log(" DSA sheet question toggling:", { id, field, questionDifficulty, topicName });
 
-    // ✅ ACCEPTANCE CRITERIA #3: Marking DSA questions does NOT affect POTD
+    //  ACCEPTANCE CRITERIA #3: Marking DSA questions does NOT affect POTD
     // This function only updates DSA sheet progress, no POTD interaction
 
     // Fail-safe: recover topicName if missing


### PR DESCRIPTION

### Related Issue(s)

* Fixes #384

---

### Summary

This PR implements the **one-way sync feature** from **POTD → DSA sheet**, ensuring progress is consistently tracked while maintaining independence of POTD’s date-based behavior.

The solution satisfies all acceptance criteria:

* Marking POTD as done automatically checks the corresponding DSA list question.
* Repeated POTD questions always start unchecked (date-based status).
* DSA sheet updates do not affect POTD (strict one-way sync).
* All changes persist reliably in `localStorage` with real-time UI updates.

---

### Changes

* 🔧 **Enhanced POTD Component**

  * Added robust question matching logic (by ID + title).
  * Implemented sync logic with custom event dispatch for real-time UI updates.

* 🔧 **Enhanced SheetContent Component**

  * Added `localStorage` change listeners for cross-component and cross-tab synchronization.

* 📄 **Documentation & Testing**

  * Created `POTD_SYNC_TEST_GUIDE.md` with comprehensive testing instructions.
  * Added console logging for debugging and graceful error handling.

---

### Screenshots (if applicable)

<!-- Drag & drop images or paste links -->  

---

### How to Test

1. Mark a POTD as done → the corresponding DSA sheet question should auto-check.
2. Check that a repeated POTD question appears **unchecked**, even if already solved in DSA.
3. Confirm that marking a DSA sheet question does **not** affect POTD status.
4. Verify persistence across reloads and tabs (localStorage + event-driven sync).

---

### Checklist

* [x] I linked a related issue using `Fixes #<issue_number>`
* [x] I am GSSoC'25 contributor
* [x] I am Hacktoberfest'25 contributor
* [x] I tested locally and verified the changes work as expected
* [x] I updated docs or comments where needed

---

> **Note:** Please ensure that appropriate labels (like `gssoc25` and difficulty level labels) are assigned to the **merged PR** so that contribution points are counted properly.

