### PR TITLE
Fix profile 404 by routing to /profile/[userId]; make cookies secure …

### DIFF
--- a/app/api/(auth)/signIn-verify-Otp/route.ts
+++ b/app/api/(auth)/signIn-verify-Otp/route.ts
@@ -74,7 +74,7 @@ export async function POST(req: NextRequest) {
     // Set cookie
     (await cookies()).set("session", token, {
       httpOnly: true,
-      secure: true,
+      secure: process.env.NODE_ENV === "production",
       sameSite: "strict",
       maxAge: 60 * 60 * 24 * 7,
       path: "/",

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -74,7 +74,7 @@ export async function GET(req: Request) {
     const res = NextResponse.redirect(`${process.env.NEXT_PUBLIC_BASE_URL}/`);
     res.cookies.set("session", token, {
       httpOnly: true,
-      secure: true,
+      secure: process.env.NODE_ENV === "production",
       sameSite: "strict",
       path: "/",
       maxAge: 60 * 60 * 24 * 7,

--- a/app/api/google/callback/route.ts
+++ b/app/api/google/callback/route.ts
@@ -73,7 +73,7 @@ export async function GET(req: Request) {
     
     res.cookies.set("session", token, {
       httpOnly: true,
-       secure: true,
+      secure: process.env.NODE_ENV === "production",
       sameSite: "strict",
       path: "/",
       maxAge: 60 * 60 * 24 * 7,

--- a/app/api/test/route.ts
+++ b/app/api/test/route.ts
@@ -1,9 +1,0 @@
-import { NextResponse } from "next/server";
-
-export async function GET() {
-    return NextResponse.json({
-        success: true,
-        message: "Test API is working!",
-        timestamp: new Date().toISOString()
-    });
-}

--- a/components/NavbarSheet.tsx
+++ b/components/NavbarSheet.tsx
@@ -407,14 +407,14 @@ export default function NavbarSheet({
                     <p className="text-xs text-muted-foreground">{user.email}</p>
                   </div>
                   <Link 
-                    href="/profile" 
+                    href={user?`/profile/${encodeURIComponent(user._id)}`:"#"} 
                     onClick={() => setOpenDropdown(null)}
                     className="block px-4 py-2.5 text-sm text-foreground hover:bg-muted/50 hover:text-blue-400 transition-all"
                   >
                     Profile
                   </Link>
                   <Link 
-                    href="/dashboard" 
+                    href="/progress" 
                     onClick={() => setOpenDropdown(null)}
                     className="block px-4 py-2.5 text-sm text-foreground hover:bg-muted/50 hover:text-blue-400 transition-all"
                   >
@@ -627,10 +627,10 @@ export default function NavbarSheet({
                   <p className="text-xs text-muted-foreground">{user.email}</p>
                 </div>
               </div>
-              <Link href="/profile" className="block px-6 py-2.5 text-foreground hover:bg-muted/50 hover:text-blue-400 transition-all">
+              <Link href={user?`/profile/${encodeURIComponent(user._id)}`:"#"} className="block px-6 py-2.5 text-foreground hover:bg-muted/50 hover:text-blue-400 transition-all">
                 Profile
               </Link>
-              <Link href="/dashboard" className="block px-6 py-2.5 text-foreground hover:bg-muted/50 hover:text-blue-400 transition-all">
+              <Link href="/progress" className="block px-6 py-2.5 text-foreground hover:bg-muted/50 hover:text-blue-400 transition-all">
                 Dashboard
               </Link>
               <button onClick={handleLogout} className="block w-full text-left px-6 py-2.5 text-foreground hover:bg-muted/50 hover:text-red-400 transition-all">


### PR DESCRIPTION
Here’s your PR body, ready to paste.

…only in production; point Dashboard to /progress; remove debug test route

### Related Issue(s)
- Fixes #406 

### Summary
- Profile navigation was linking to a non-existent route (/profile), which caused a 404 after login. The actual implemented page is /profile/[userId].
- Local logins (GitHub/Google/OTP) failed to persist sessions because cookies were always set with secure: true, which most browsers reject on http://localhost.
- Navbar “Dashboard” item pointed to a non-existent /dashboard path; the real page is /progress.
- A temporary debug test endpoint was present and is removed.

### Changes
- Update navbar links:
  - Profile → `/profile/${user._id}`
  - Dashboard → `/progress`
- Set session cookies to secure only in production:
  - `app/api/github/callback/route.ts`
  - `app/api/google/callback/route.ts`
  - `app/api/(auth)/signIn-verify-Otp/route.ts`
- Remove temporary debug endpoint:
  - Delete `app/api/test/route.ts`

### Screenshots (if applicable)
<img width="1918" height="892" alt="image" src="https://github.com/user-attachments/assets/31099aa4-1b4a-45e6-8f06-d283201c4709" />

![demooo](https://github.com/user-attachments/assets/de965274-77a5-4610-9428-66abb18ab8b7)


### How to Test
1. Ensure `.env.local` has valid `MONGO_URI`, `JWT_SECRET`, `NEXT_PUBLIC_BASE_URL=http://localhost:3000`, and GitHub OAuth variables with callback `http://localhost:3000/api/github/callback`.
2. Run `npm run dev`, open `http://localhost:3000/api/github`, authorize, and return to the app.
3. From the navbar:
   - Click Profile → navigates to `/profile/<yourUserId>` and loads.
   - Click Dashboard → navigates to `/progress` and loads.
4. Refresh the page; session remains active locally.

### Checklist
- [x] I linked a related issue using `Fixes #<issue_number>`
- [x] I am GSSoC'25 contributor
- [x] I am Hacktoberfest'25 contributor
- [x] I tested locally and verified the changes work as expected
- [x] I updated docs or comments where needed