### PR TITLE
fix: improve testimonial prompt visibility in light mode

### DIFF
--- a/components/TestimonialPrompt.tsx
+++ b/components/TestimonialPrompt.tsx
@@ -26,7 +26,6 @@ export default function TestimonialPrompt() {
     px-3 py-2 rounded-lg shadow-md 
     w-[85vw] max-w-[300px] sm:px-4 sm:py-3"
 >
-  console.log('Testimonials:', testimonials);
 
       <div className="relative">
         {/* Close Button */}


### PR DESCRIPTION
### Related Issue(s)
- Fixes #<issue_number>

### Summary
Briefly explain the problem and how this PR solves it.
Main container background/text

Old: bg-[#202029] text-white

New: bg-white text-gray-800 dark:bg-[#202029] dark:text-white

Hover effect

Old: hover:bg-[#19191f]

New: hover:bg-gray-100 dark:hover:bg-[#19191f]

Close button

Old: text-gray-400 hover:text-white

New: text-gray-500 hover:text-black dark:text-gray-400 dark:hover:text-white

### Checklist
- [yes ] I linked a related issue using `Fixes #<issue_number>`
- [yes ] I am GSSoC'25 contributor
- [ yes] I am Hacktoberfest'25 contributor
- [ yes] I tested locally and verified the changes work as expected
- [yes ] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.
