### PR TITLE
 Improved visibility of Terms of Service and Privacy Policy button

### DIFF
--- a/app/privacy-terms/page.tsx
+++ b/app/privacy-terms/page.tsx
@@ -85,7 +85,7 @@ function PrivacyTermsContent() {
                 className={`px-6 py-3 rounded-lg font-medium transition-all duration-300 ${
                   activeTab === 'privacy'
                     ? 'bg-gradient-to-r from-blue-500 to-purple-500 text-white shadow-lg'
-                    : 'text-gray-400 hover:text-foreground dark:hover:text-white'
+                    : 'text-gray-950 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-300'
                 }`}
               >
                 Privacy Policy
@@ -95,7 +95,7 @@ function PrivacyTermsContent() {
                 className={`px-6 py-3 rounded-lg font-medium transition-all duration-300 ${
                   activeTab === 'terms'
                     ? 'bg-gradient-to-r from-blue-500 to-purple-500 text-white shadow-lg'
-                    : 'text-gray-400 hover:text-foreground dark:hover:text-white'
+                    : 'text-gray-950 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-300'
                 }`}
               >
                 Terms of Service


### PR DESCRIPTION
### Related Issue(s)
- Fixes #308 

### Summary
The "Terms of Service" and "Privacy Policy" links were previously a light grey color, which blended with the background and made them hard to read. This PR updates   the text to intial to text-gray-950 and in dark mode to text-gray-300 and when activate to white.

### Changes
- Initial to text-gray-950 in light mode and in text-gray-300 in dark mode
- In Hover condition to text-gray-700 in light mode  and text-gray-300 in dark mode

### Screenshots (if applicable)
<!-- Drag & drop images or paste links -->
<img width="425" height="111" alt="Screenshot 2025-10-12 160014" src="https://github.com/user-attachments/assets/654d5370-35c6-4d67-8593-d85dd0c5b2a4" />
<img width="458" height="131" alt="Screenshot 2025-10-12 160002" src="https://github.com/user-attachments/assets/7ba76210-519a-4d71-bb19-dd01083fdecc" />


### Checklist
- [x] I linked a related issue using `Fixes #308 `
- [x] I am Hacktoberfest'25 contributor
- [x] I tested locally and verified the changes work as expected

 
