### PR TITLE
Updates testimonials to be visible in light mode

### DIFF
--- a/components/ui/animated-tooltip.tsx
+++ b/components/ui/animated-tooltip.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import React, { useState, useRef } from "react";
 import {
   motion,
@@ -26,11 +25,11 @@ export const AnimatedTooltip = ({
 
   const rotate = useSpring(
     useTransform(x, [-100, 100], [-45, 45]),
-    springConfig,
+    springConfig
   );
   const translateX = useSpring(
     useTransform(x, [-100, 100], [-50, 50]),
-    springConfig,
+    springConfig
   );
 
   const handleMouseMove = (event: any) => {
@@ -43,6 +42,8 @@ export const AnimatedTooltip = ({
       x.set(event.nativeEvent.offsetX - halfWidth);
     });
   };
+
+  
 
   return (
     <>
@@ -73,14 +74,15 @@ export const AnimatedTooltip = ({
                   rotate: rotate,
                   whiteSpace: "nowrap",
                 }}
-                className="absolute -top-16 left-1/2 z-50 flex -translate-x-1/2 flex-col items-center justify-center rounded-md bg-black px-4 py-2 text-xs shadow-xl"
+                className="absolute -top-16 left-1/2 z-50 flex -translate-x-1/2 flex-col items-center justify-center rounded-md bg-white dark:bg-black px-4 py-2 text-xs shadow-xl"
               >
                 <div className="absolute inset-x-10 -bottom-px z-30 h-px w-[20%] bg-gradient-to-r from-transparent via-emerald-500 to-transparent" />
+
                 <div className="absolute -bottom-px left-10 z-30 h-px w-[40%] bg-gradient-to-r from-transparent via-sky-500 to-transparent" />
-                <div className="relative z-30 text-base font-bold text-white">
+                <div className="relative z-30 text-base font-bold text-black dark:text-white">
                   {item.name}
                 </div>
-                <div className="text-xs text-white">{item.designation}</div>
+                <div className="text-xs text-black dark:text-white">{item.designation}</div>
               </motion.div>
             )}
           </AnimatePresence>


### PR DESCRIPTION
### Related Issue(s)
- Fixes #345 

### Summary
- Previously, the testimonials section was not properly visible in light mode due to missing or incorrect color contrast.
This PR fixes the issue by updating text and background styles to ensure good visibility in both light and dark modes.

### Changes
- Updated testimonial text color for light mode visibility
- Adjusted background contrast to match theme
- Verified compatibility with Tailwind’s dark: mode for theme switching

### How to Test
1. Switch between light and dark themes.
2. Navigate to the testimonials section.
3. Verify that text and backgrounds are clearly visible in both modes.

### Checklist
- [x] I linked a related issue using `Fixes #<issue_number>`
- [x] I am GSSoC'25 contributor
- [x] I am Hacktoberfest'25 contributor
- [x] I tested locally and verified the changes work as expected
- [x] I updated docs or comments where needed

> Note: Please ensure that appropriate labels (like `gssoc25` and level labels) are assigned to the **merged PR**.  
> Sometimes it may be missed by PA or mentors, so kindly double-check — otherwise, points won’t be counted.