### PR TITLE
feat: add password generator and strength indicator

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,24 @@
+# Environment Variables Example
+# Copy this file to .env and fill in the values
+
+
+NODE_ENV= # Set to 'development', 'production', or 'test'
+JWT_SECRET= # Your JWT secret key
+GEMINI_KEY= # Your Gemini API key
+GITHUB_TOKEN= # Your GitHub token
+GITHUB_CLIENT_ID= # Your GitHub OAuth client ID
+GITHUB_REDIRECT_URI= # Your GitHub OAuth redirect URI
+NEXT_PUBLIC_BASE_URL= # Your application's base URL
+GOOGLE_REDIRECT_URI= # Your Google OAuth redirect URI
+GOOGLE_CLIENT_ID= # Your Google OAuth client ID
+GOOGLE_CLIENT_SECRET= # Your Google OAuth client secret
+GOOGLE_API_KEY= # Your Google Gemini API key
+CRON_SECRET= # Secret for cron jobs
+GOOGLE_APP_USER= # Google app user email
+GOOGLE_APP_PASSWORD= # Google app user password
+MONGO_URI= mongodb+srv://krishsharma1505:hello@123@dsamate-user.mtp5ac4.mongodb.net/?retryWrites=true&w=majority&appName=dsamate-user
+NEXT_PHASE= # Next.js phase (e.g., 'development', 'production')
+
+# Node Mailer
+GOOGLE_APP_USER= # Your email address for sending emails
+GOOGLE_APP_PASSWORD= # Your email password or app-specific password


### PR DESCRIPTION
Hi there!

Apologies for opening a new Pull Request. I accidentally closed the original PR (#442 ) by deleting my fork before I could add the demonstration screenshots.

Description:
This PR enhances the user experience and security of the sign-up form by implementing a secure password generator and a real-time password strength indicator as requested in issue #401 .

| Before | After |
| :---: | :---: |
| ![Before Screenshot](https://github.com/user-attachments/assets/f437f18f-f1c8-4c94-8928-8522ffa682c2)      |   ![After Screenshot](https://github.com/user-attachments/assets/85e2b5b6-4c58-4763-9d9d-034bfe9d85ca) |

Fixes #401 

Changes/Additions: 
- Added a `key icon` that generates strong passwords in both `password` and `confirm password` when clicked.
- Added a `password strength indicator`, green being strongest and red being weakest

Testing: 
This feature was thoroughly tested on my local development server:
[x] Verified that the generator button correctly creates and fills a strong password.

[x] Verified that the strength indicator updates in real-time as a user types.
